### PR TITLE
added experimental wit files for enabling reactive programming model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blob-experiment"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "wit-bindgen-rust",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "examples/kv-filesystem-config",
     "examples/kv-azure-blob-config",
     "examples/kv-demo",
+    "examples/blob-experiment"
 ]
 
 [[bin]]

--- a/examples/blob-experiment/Cargo.toml
+++ b/examples/blob-experiment/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "blob-experiment"
+version = "0.1.0"
+edition = "2021"
+authors = ["DeisLabs Engineering Team"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+anyhow = "1"

--- a/examples/blob-experiment/src/main.rs
+++ b/examples/blob-experiment/src/main.rs
@@ -1,0 +1,36 @@
+use anyhow::Result;
+
+use event_handler::*;
+use resources::{Bucket, SqlDatabase, Events};
+
+wit_bindgen_rust::import!("../../wit/experimental/resources.wit");
+wit_bindgen_rust::export!("../../wit/experimental/event-handler.wit");
+
+fn main() -> Result<()> {
+    let bucket = Bucket::get()?;
+    let sql_database = SqlDatabase::new()?;
+
+    let events = Events::get()?;
+    events
+        .listen(&bucket.on("my-key")?)?
+        .listen(&sql_database.on("my-table")?)?
+        .listen(&bucket.on("my-key2")?)?
+        .exec()
+        .map_err(|e| e.into())
+}
+
+impl From<resources::Error> for anyhow::Error {
+    fn from(e: resources::Error) -> Self {
+        anyhow::anyhow!("blob error: {:?}", e)
+    }
+}
+
+pub struct EventHandler {}
+
+impl event_handler::EventHandler for EventHandler {
+    fn handle_event(ev: event_handler::Event,) -> Result<Option<event_handler::Event>,Error> {
+        println!("{:?}", ev.source);
+        println!("{:?}", ev.event_type);
+        Ok(Some(ev))
+    }
+}

--- a/wit/experimental/event-handler.wit
+++ b/wit/experimental/event-handler.wit
@@ -1,0 +1,5 @@
+type error = string
+
+use { event } from event
+
+handle-event: function(ev: event) -> expected<option<event>, error>

--- a/wit/experimental/event.wit
+++ b/wit/experimental/event.wit
@@ -1,0 +1,7 @@
+record event {
+	specversion: string,
+	event-type: string,
+	source: string,
+	id: string,
+	data: option<string>
+}

--- a/wit/experimental/observer.wit
+++ b/wit/experimental/observer.wit
@@ -1,0 +1,8 @@
+type error = string
+
+use { event } from event 
+
+resource observer {
+	// listen for changes.
+	observe: function() -> expected<event, error>
+}

--- a/wit/experimental/resources.wit
+++ b/wit/experimental/resources.wit
@@ -1,0 +1,75 @@
+variant error {
+	bucket-error(string),
+	sql-error(string),
+	event-error(string),
+}
+
+type size = u64
+type payload = list<u8>
+
+use { observer } from observer
+
+// ----------------- START of blob interface ------------------
+
+// a blob interface
+resource bucket {
+	// get a blob resource descriptor.
+	static get: function() -> expected<bucket, error>
+	
+	// close the connection to the blob.
+	close: function() -> expected<unit, error>
+	
+	// delete the blob given a key
+	delete-blob: function(key: string) -> expected<unit, error>
+
+	// list all the blobs in the bucket.
+	list-blob: function() -> expected<list<string>, error>
+
+	// get a blob reader for a given key.
+	get-reader: function(key: string) -> expected<reader, error>
+
+	// get a blob writer for a given key.
+	get-writer: function(key: string) -> expected<writer, error>
+
+	// listens on the bucket for changes.
+	on: function(key: string) -> expected<observer, error>
+}
+
+resource reader {
+	// read the blob.
+	read: function() -> expected<payload, error>
+	size: function() -> expected<size, error>
+}
+
+resource writer {
+	// write the blob.
+	write: function(buf: payload) -> expected<size, error>
+}
+
+// ----------------- END of blob interface ------------------
+
+// ----------------- START of sql database interface ------------------
+resource sql-database {
+	// get a key-value store resource descriptor.
+	static new: function() -> expected<sql-database, error>
+
+	// get the payload for a given key.
+	query: function(sql: string) -> expected<unit, error>
+
+	// set the payload for a given key.
+	exec: function() -> expected<option<payload>, error>
+
+	// listens on the database for changes.
+	on: function(table-name: string) -> expected<observer, error>
+}
+// ----------------- END of sql database interface ------------------
+
+use { event } from event
+
+resource events {
+	static get: function() -> expected<events, error>
+	listen: function(ob: observer) -> expected<events, error>
+	exec: function() -> expected<unit, error>
+}
+
+


### PR DESCRIPTION
This is NOT ready to merge yet and I want to leave this PR here for collaboration! 

I had a discussion with @devigned and @khenidak on "reactive programming model" on wasi-cloud. Just like every spec we design in wasi-cloud, the idea is to design a consistent interface that offers a reactive programming style capability to cloud and distrbuted applications. The basic idea is that every supported providers, be a blob store, or a sql database, or others, must implement a `on` function to observe changes and emits change events. For example, update key is a change and if it's being specified in `on`, it will generate an updatekey event to the host. User could specify an event listener that listens to one or more observers, and decide to offload the execution logic to the application.

The following is an exmaple of using this capability in Rust. 
```rust
fn main() -> Result<()> {
    let bucket = Bucket::get()?;
    let sql_database = SqlDatabase::new()?;

    let events = Events::get()?;
    events
        .listen(&bucket.on("my-key")?)?
        .listen(&sql_database.on("my-table")?)?
        .listen(&bucket.on("my-key2")?)?
        .exec()
        .map_err(|e| e.into())
}
```

You may ask, how does the guest specify how to react to an event? The guest will need to implement the `event-handler.wit` interface and the host will invoke the `handle_event()` function and pass an event to the guest to process.

```rust
pub struct EventHandler {}
impl event_handler::EventHandler for EventHandler {
    fn handle_event(ev: event_handler::Event,) -> Result<Option<event_handler::Event>,Error> {
        println!("{:?}", ev.source);
        println!("{:?}", ev.event_type);
        Ok(Some(ev))
    }
}
```



## Discussion
- We should support a single watch interface across all providers
- This proposal assumes a consistent event scheme, and it takes inspiration from [CloudEvents](https://cloudevents.io/).
- This PR only proposes `.wit` interfaces for watch. A follow up PR should implement a host for it. 




Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>