### PR TITLE
Making the pubsub and lockd interface interactions more generic

### DIFF
--- a/crates/lockd-etcd/src/lib.rs
+++ b/crates/lockd-etcd/src/lib.rs
@@ -43,8 +43,10 @@ impl LockdEtcd {
 
 impl lockd::Lockd for LockdEtcd {
     /// Construct a new `LockdEtcd` instance
-    fn get_lockd(&mut self, name: &str) -> Result<ResourceDescriptorResult, Error> {
-        let etcd_lockd = Self::new(name);
+    fn get_lockd(&mut self) -> Result<ResourceDescriptorResult, Error> {
+        let endpoint = std::env::var("ETCD_ENDPOINT")
+            .with_context(|| "failed to read ETCD_ENDPOINT environment variable")?;
+        let etcd_lockd = Self::new(&endpoint);
         self.inner = etcd_lockd.inner;
 
         let rd = Uuid::new_v4().to_string();

--- a/crates/pubsub-confluent-kafka/src/lib.rs
+++ b/crates/pubsub-confluent-kafka/src/lib.rs
@@ -66,8 +66,9 @@ impl PubSubConfluentKafka {
 
 impl pubsub::Pubsub for PubSubConfluentKafka {
     /// Construct a new `PubSubConfluentKafka`
-    fn get_pubsub(&mut self, name: &str) -> Result<ResourceDescriptorResult, Error> {
-        let bootstap_servers = name;
+    fn get_pubsub(&mut self) -> Result<ResourceDescriptorResult, Error> {
+        let bootstap_servers = env::var("CK_ENDPOINT")
+            .with_context(|| "failed to read CK_ENDPOINT environment variable")?;
         let security_protocol = env::var("CK_SECURITY_PROTOCOL")
             .with_context(|| "failed to read CK_SECURITY_PROTOCOL environment variable")?;
         let sasl_mechanisms = env::var("CK_SASL_MECHANISMS")
@@ -80,7 +81,7 @@ impl pubsub::Pubsub for PubSubConfluentKafka {
             .with_context(|| "failed to read CK_GROUP_ID environment variable")?;
 
         let ck_pubsub = Self::new(
-            bootstap_servers,
+            &bootstap_servers,
             &security_protocol,
             &sasl_mechanisms,
             &sasl_username,

--- a/examples/lockd-demo/src/main.rs
+++ b/examples/lockd-demo/src/main.rs
@@ -10,7 +10,7 @@ wit_error_rs::impl_error!(Error);
 use anyhow::Result;
 
 fn main() -> Result<()> {
-    let lockd = get_lockd("localhost:2379")?;
+    let lockd = get_lockd()?;
 
     println!("trying to acquire a lock with 5s time to live");
     let mut now = SystemTime::now();

--- a/examples/pubsub-consumer-demo/src/main.rs
+++ b/examples/pubsub-consumer-demo/src/main.rs
@@ -6,7 +6,7 @@ wit_bindgen_rust::import!("../../wit/pubsub.wit");
 wit_error_rs::impl_error!(Error);
 
 fn main() -> Result<()> {
-    let resource_descriptor = get_pubsub("pkc-epwny.eastus.azure.confluent.cloud:9092")?;
+    let resource_descriptor = get_pubsub()?;
     let now = SystemTime::now();
     subscribe_to_topic(&resource_descriptor, &["rust"])?;
     let timeout_as_secs = 30;

--- a/examples/pubsub-producer-demo/src/main.rs
+++ b/examples/pubsub-producer-demo/src/main.rs
@@ -6,7 +6,7 @@ wit_bindgen_rust::import!("../../wit/pubsub.wit");
 wit_error_rs::impl_error!(Error);
 
 fn main() -> Result<()> {
-    let resource_descriptor = get_pubsub("pkc-epwny.eastus.azure.confluent.cloud:9092")?;
+    let resource_descriptor = get_pubsub()?;
     for i in 0..3 {
         println!("sending message");
         send_message_to_topic(

--- a/wit/lockd.wit
+++ b/wit/lockd.wit
@@ -3,7 +3,7 @@ use { error, payload } from types
 use * from resources
 
 // get a resource descriptor for a lockd object
-get-lockd: function(name: string) -> expected<resource-descriptor, error>
+get-lockd: function() -> expected<resource-descriptor, error>
 
 // creates a lock with a name, returns the lock key
 lock: function(rd: resource-descriptor, lock-name: payload) -> expected<payload, error>

--- a/wit/pubsub.wit
+++ b/wit/pubsub.wit
@@ -3,7 +3,7 @@ use { message, error, payload } from types
 use * from resources
 
 // get the resource-descriptor for pub/sub
-get-pubsub: function(name: string) -> expected<resource-descriptor, error>
+get-pubsub: function() -> expected<resource-descriptor, error>
 
 // pub a message
 send-message-to-topic: function(rd: resource-descriptor, msg-key: payload, msg-value: payload, topic: string) -> expected<unit, error> 


### PR DESCRIPTION
Once merged, this PR closes #45.

I'm moving the endpoint definition (for etcdlockd, and ckpubsub) from the guest code to an environment variable. I think this is the best way to generalize it right now without any big modifications to config, which are still up-for-design. Moving forward, I think I will tackle improving our config work (i.e., perhaps adding a key-vault service) and then, perhaps, this and all other services can be reformatted to get their required configs dynamically. All in all, this is sort of a temporary solution until we have a better way to handle secrets/settings.

Signed-off-by: Dan Chiarlone <dchiarlone@microsoft.com>