### PR TITLE
feat: Removed check and unittests from az pipeline

### DIFF
--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -132,22 +132,6 @@ stages:
           #
           # Build
           #
-          - script: make improve
-            displayName: Run rust-clippy and rustfmt
-            condition: and(succeeded(), eq(variables['target_os'], 'windows'))
-            env:
-              OPENSSL_DIR: C:\Program Files\OpenSSL-Win64\
-          
-          - script: make improve
-            displayName: Run rust-clippy and rustfmt
-            condition: and(succeeded(), eq(variables['target_os'], 'linux'))
-          
-          - script: make improve
-            displayName: Run rust-clippy and rustfmt
-            condition: and(succeeded(), eq(variables['target_os'], 'macos'))
-            env:
-              OPENSSL_ROOT_DIR: /usr/local/opt/openssl
-          
           - script: make build
             displayName: Build
             condition: and(succeeded(), eq(variables['target_os'], 'windows'))
@@ -172,11 +156,8 @@ stages:
           #   displayName: Build C Examples
           
           #
-          # Running all tests
+          # Running integration tests
           #
-          - script: make test
-            displayName: Run Unit Tests
-          
           - script: make test-integration
             displayName: Run Integration Tests
             env:


### PR DESCRIPTION
I've noticed that, in avg, it takes 17 mins to execute `make improve` on windows machines. Considering that we are running both `make improve` and unittests on GH action, there is no need to run them again in our integration pipeline. This PR removes them, and hopefully will make our integration pipeline faster to finish. 

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>