### PR TITLE
adding a devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:22.04
+
+WORKDIR /home/
+
+COPY . .
+
+ENV PATH="/root/.cargo/bin:$PATH"
+
+RUN bash ./setup.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+	"name": "Codespaces Rust Starter",
+	"extensions": [
+		"matklad.rust-analyzer",
+		"serayuzgur.crates",
+		"vadimcn.vscode-lldb",
+		"ms-vscode.makefile-tools",
+		"ms-vscode.cpptools-extension-pack"
+	],
+	"dockerFile": "Dockerfile",
+	"settings": {
+		"editor.formatOnSave": true,
+		"terminal.integrated.profiles.linux": {
+			"zsh": {
+				"path": "/usr/bin/zsh",
+				"environment": [
+					"RUST_BACKTRACE=1",
+					"RUST_LOG=debug",
+					"RUST_LOG_STYLE=always"
+				]
+			}
+		},
+		"terminal.integrated.defaultProfile.linux": "zsh",
+		"files.exclude": {
+			"**/CONTRIBUTING.md": true,
+			"**/LICENSE": true
+		}
+	}
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+## update and install 1st level of packages
+apt-get update
+apt-get install -y \
+    curl \
+    git \
+    gnupg2 \
+    jq \
+    sudo \
+    zsh \
+    build-essential \
+    cmake \
+    libssl-dev \
+    openssl \
+    unzip
+
+## update and install 2nd level of packages
+apt-get install -y pkg-config
+
+## install rustup and common components
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+rustup install nightly
+rustup component add rustfmt
+rustup component add rustfmt --toolchain nightly
+rustup component add clippy
+rustup component add clippy --toolchain nightly
+
+cargo install cargo-expand
+cargo install cargo-edit
+cargo install --git https://github.com/bytecodealliance/wit-bindgen wit-bindgen-cli --rev a79a4be33d76ddf62839ba71602c26a96610ef7c
+rustup target add wasm32-wasi
+
+## setup git
+git config --global core.editor "code --wait"


### PR DESCRIPTION
First stage for #166 - adding a `.devcontainer` setup.
The configuration is mainly based on the [GitHub Codespaces Rust example](https://github.com/codespaces-examples/rust).

It is comprised of a
- Ubuntu 22.04 base image
- basic Rust and Cargo components to allow development for this project within a Codespace
- required `wit-bindgen-cli` and Rust `wasm32-wasi` target
- basic Visual Studio Code extensions for C and Rust development within a Codespace