### PR TITLE
refactor: removed unused config in Builder

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -22,7 +22,6 @@ pub struct Builder {
     linker: Linker<Ctx>,
     store: Store<Ctx>,
     engine: Engine,
-    pub config: Option<Vec<(String, String)>>,
 }
 
 impl Builder {
@@ -44,7 +43,6 @@ impl Builder {
             linker,
             store,
             engine,
-            config: None,
         })
     }
 


### PR DESCRIPTION
We are no longer using `config` in `Builder` anymore because #85 adds configuration capability to SpiderLightning that can take care of resource configurations. This PR removes this field from `Builder`. 

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>