### PR TITLE
chore: update azure blob version to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,27 +672,26 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e2c7582699a3af9cc8a7bc81259519d8afb8eded1090d4fcd86de3db0eace1"
+checksum = "e6e66a6d993197d1b575cffd08bf725e04bc1414de6586baeb3537925e49b4ff"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
  "bytes 1.2.1",
- "chrono",
  "dyn-clone",
  "futures",
  "getrandom 0.2.7",
- "http",
+ "http-types",
  "log",
- "oauth2",
+ "paste",
  "pin-project",
  "rand 0.8.5",
  "reqwest",
  "rustc_version 0.4.0",
  "serde",
- "serde_derive",
  "serde_json",
+ "time 0.3.13",
  "url",
  "uuid 1.1.2",
 ]
@@ -716,19 +715,17 @@ dependencies = [
 
 [[package]]
 name = "azure_storage"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a5bc29e999268e618c202f157291930d749f1e4de55e01ecfda3990dd37dc7"
+checksum = "55aa63fb0426c76b9cc909234e94e69764f5e777a62b7ed6411f3cc04aa94a16"
 dependencies = [
  "RustyXML",
  "async-trait",
- "azure_core 0.3.0",
+ "azure_core 0.4.0",
  "base64 0.13.0",
  "bytes 1.2.1",
- "chrono",
  "futures",
  "hmac 0.12.1",
- "http",
  "log",
  "once_cell",
  "serde",
@@ -736,30 +733,30 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.2",
+ "time 0.3.13",
  "url",
  "uuid 1.1.2",
 ]
 
 [[package]]
 name = "azure_storage_blobs"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2baa5f9f6c9e4ee9d096d2e21d21c4a5f120e9a0bbcd3ee7c8abb74b008b631"
+checksum = "33f953cedd7c240347ed0f6ed8a0bd7472b32579c38341ab9e117eaa6173e9ba"
 dependencies = [
  "RustyXML",
- "azure_core 0.3.0",
+ "azure_core 0.4.0",
  "azure_storage",
  "base64 0.13.0",
  "bytes 1.2.1",
- "chrono",
  "futures",
- "http",
  "log",
  "md5",
  "serde",
  "serde-xml-rs",
  "serde_derive",
  "serde_json",
+ "time 0.3.13",
  "url",
  "uuid 1.1.2",
 ]
@@ -3689,7 +3686,7 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-dynamodb",
- "azure_core 0.3.0",
+ "azure_core 0.4.0",
  "azure_storage",
  "azure_storage_blobs",
  "bytes 1.2.1",
@@ -4105,7 +4102,7 @@ dependencies = [
  "libc",
  "standback",
  "stdweb",
- "time-macros",
+ "time-macros 0.1.1",
  "version_check",
  "winapi",
 ]
@@ -4116,8 +4113,11 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
+ "itoa",
  "libc",
  "num_threads",
+ "serde",
+ "time-macros 0.2.4",
 ]
 
 [[package]]
@@ -4129,6 +4129,12 @@ dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "time-macros-impl"

--- a/crates/kv/Cargo.toml
+++ b/crates/kv/Cargo.toml
@@ -19,9 +19,9 @@ uuid = { version = "1.1", features = ["v4"] }
 crossbeam-channel = "0.5"
 tracing = { version = "0.1", features = ["log"] }
 # kv.azblob deps
-azure_storage_blobs = "0.4"
-azure_storage = "0.4"
-azure_core = "0.3"
+azure_storage_blobs = "0.5"
+azure_storage = "0.5"
+azure_core = "0.4"
 bytes = "1"
 futures = "0.3"
 # kv.filesystem deps

--- a/crates/kv/src/implementors/azblob.rs
+++ b/crates/kv/src/implementors/azblob.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use azure_storage::clients::StorageAccountClient;
-use azure_storage_blobs::prelude::{AsBlobClient, AsContainerClient, ContainerClient};
+use azure_storage::clients::StorageClient;
+use azure_storage_blobs::prelude::{AsBlobServiceClient, AsContainerClient, ContainerClient};
 use futures::executor::block_on;
 use slight_runtime::resource::BasicState;
 
@@ -17,7 +17,7 @@ use crate::providers::azure;
 /// As per its' usage in `KvImplementor`, it must `derive` `Debug`, and `Clone`.
 #[derive(Debug, Clone)]
 pub struct AzBlobImplementor {
-    container_client: Option<Arc<ContainerClient>>,
+    container_client: ContainerClient,
 }
 
 impl AzBlobImplementor {
@@ -53,30 +53,21 @@ impl AzBlobImplementor {
         )
         .unwrap();
 
-        let http_client = azure_core::new_http_client();
-        let container_client = Some(
-            StorageAccountClient::new_access_key(
-                http_client.clone(),
-                storage_account_name,
-                storage_account_key,
-            )
-            .as_container_client(name),
-        );
+        let container_client =
+            StorageClient::new_access_key(storage_account_name, storage_account_key)
+                .container_client(name);
         Self { container_client }
     }
 
     pub fn get(&self, key: &str) -> Result<Vec<u8>> {
-        let inner = self.container_client.as_ref().unwrap();
-        let blob_client = inner.as_blob_client(key);
+        let blob_client = self.container_client.blob_client(key);
         let res = block_on(azure::get(blob_client))
             .with_context(|| format!("failed to get value for key {}", key))?;
         Ok(res)
     }
 
     pub fn set(&self, key: &str, value: &[u8]) -> Result<()> {
-        let inner = self.container_client.as_ref().unwrap();
-
-        let blob_client = inner.as_blob_client(key);
+        let blob_client = self.container_client.blob_client(key);
         let value = Vec::from(value);
         block_on(azure::set(blob_client, value))
             .with_context(|| format!("failed to set value for key '{}'", key))?;
@@ -84,8 +75,7 @@ impl AzBlobImplementor {
     }
 
     pub fn delete(&self, key: &str) -> Result<()> {
-        let inner = &self.container_client.as_ref().unwrap();
-        let blob_client = inner.as_blob_client(key);
+        let blob_client = self.container_client.blob_client(key);
         block_on(azure::delete(blob_client)).with_context(|| "failed to delete key's value")?;
         Ok(())
     }

--- a/crates/kv/src/implementors/azblob.rs
+++ b/crates/kv/src/implementors/azblob.rs
@@ -1,8 +1,6 @@
-use std::sync::Arc;
-
 use anyhow::{Context, Result};
 use azure_storage::clients::StorageClient;
-use azure_storage_blobs::prelude::{AsBlobServiceClient, AsContainerClient, ContainerClient};
+use azure_storage_blobs::prelude::{AsContainerClient, ContainerClient};
 use futures::executor::block_on;
 use slight_runtime::resource::BasicState;
 

--- a/crates/kv/src/lib.rs
+++ b/crates/kv/src/lib.rs
@@ -99,6 +99,7 @@ impl slight_runtime::resource::Watch for KvInner {
 /// This defines the available implementor implementations for the `Kv` interface.
 ///
 /// As per its' usage in `KvInner`, it must `derive` `Debug`, and `Clone`.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 enum KvImplementors {
     Filesystem(FilesystemImplementor),

--- a/crates/kv/src/providers/azure.rs
+++ b/crates/kv/src/providers/azure.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use azure_storage_blobs::prelude::{BlobClient, DeleteSnapshotsMethod};
-use bytes::Bytes;
 use futures::stream::StreamExt;
 
 /// Get the value given a `blob_client`

--- a/crates/kv/src/providers/azure.rs
+++ b/crates/kv/src/providers/azure.rs
@@ -1,35 +1,41 @@
 use anyhow::Result;
-use azure_storage_blobs::prelude::BlobClient;
+use azure_storage_blobs::prelude::{BlobClient, DeleteSnapshotsMethod};
 use bytes::Bytes;
-use std::sync::Arc;
+use futures::stream::StreamExt;
 
 /// Get the value given a `blob_client`
-pub async fn get(blob_client: Arc<BlobClient>) -> Result<Vec<u8>> {
-    let res = blob_client
-        .get()
-        .execute()
-        .await
-        .map_err(|e| anyhow::anyhow!("{:?}", e))?;
-    Ok(Bytes::from(res.data.to_vec()).to_vec())
+pub async fn get(blob_client: BlobClient) -> Result<Vec<u8>> {
+    let mut stream = blob_client.get().chunk_size(128u64).into_stream();
+    let mut result = vec![];
+    // The stream is composed of individual calls to the get blob endpoint
+    while let Some(value) = stream.next().await {
+        let mut body = value?.data;
+        // For each response, we stream the body instead of collecting it all into one large allocation.
+        while let Some(value) = body.next().await {
+            let value = value?;
+            println!("received {:?} bytes", value.len());
+            result.extend(&value);
+        }
+    }
+    Ok(result)
 }
 
 /// Set the value given a `blob_client` and `value`
-pub async fn set(blob_client: Arc<BlobClient>, value: Vec<u8>) -> Result<()> {
+pub async fn set(blob_client: BlobClient, value: Vec<u8>) -> Result<()> {
     blob_client
         .put_block_blob(value)
         .content_type("text/plain")
-        .execute()
-        .await
-        .map_err(|e| anyhow::anyhow!("{:?}", e))?;
+        .into_future()
+        .await?;
     Ok(())
 }
 
 /// Delete the `value` given a `blob_client`
-pub async fn delete(blob_client: Arc<BlobClient>) -> Result<()> {
+pub async fn delete(blob_client: BlobClient) -> Result<()> {
     blob_client
         .delete()
-        .execute()
-        .await
-        .map_err(|e| anyhow::anyhow!("{:?}", e))?;
+        .delete_snapshots_method(DeleteSnapshotsMethod::Include)
+        .into_future()
+        .await?;
     Ok(())
 }

--- a/tests/kv-test/src/main.rs
+++ b/tests/kv-test/src/main.rs
@@ -44,12 +44,6 @@ fn main() -> Result<()> {
     let value = kv3.get("");
     assert!(value.is_err());
 
-    // test get_kv() with empty name
-    //
-    // FIXME: not sure if this should be an error or success.
-    let kv4 = Kv::open("random4")?;
-    let _ret = kv4.delete("key");
-
     println!("finished running kv-test");
     Ok(())
 }


### PR DESCRIPTION
Besides bumping up the version of azure blob storage to `0.5`, this PR also deletes one kv test in the integration test. It deletes the last bits that test to delete a key that doesn't exist in the container. Since AWS dynamodb and azure blob storage have different semantics over this operation, one silently passed and the other throwed an error. Before we decide to go either way, I will remove the test for now. 

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>