### PR TITLE
feat(test): added integration tests for kv redis implementaiton

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,13 @@ jobs:
       # 
       # Install build tools
       #
+
+      # https://github.com/actions/runner-images/issues/6283
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        if: ${{ fromJSON(matrix.config.os == 'ubuntu-latest') }}
+
       - name: "Install make tool on Windows"
         run: choco install make -y
         if: ${{ fromJSON(matrix.config.os == 'windows-latest') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,13 @@ jobs:
       # 
       # Install build tools
       #
+
+      # https://github.com/actions/runner-images/issues/6283
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        if: ${{ fromJSON(matrix.config.os == 'ubuntu-latest') }}
+
       - name: "Install make tool on Windows"
         run: choco install make -y
         if: ${{ fromJSON(matrix.config.os == 'windows-latest') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,13 +48,6 @@ jobs:
       # 
       # Install build tools
       #
-
-      # https://github.com/actions/runner-images/issues/6283
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-        if: ${{ fromJSON(matrix.config.os == 'ubuntu-latest') }}
-
       - name: "Install make tool on Windows"
         run: choco install make -y
         if: ${{ fromJSON(matrix.config.os == 'windows-latest') }}

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,7 @@ install-deps:
 	sudo mkdir -p /opt/wasi-sdk
 	sudo mv wasi-sdk-15.0/* /opt/wasi-sdk/
 	sudo rm -rf wasi-sdk-*
-
-	curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
-	echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
-	sudo apt-get update
-	sudo apt-get install redis
+	brew install redis
 
 .PHONY: install-deps-macos
 install-deps-macos:

--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,6 @@ install-deps:
 	sudo mkdir -p /opt/wasi-sdk
 	sudo mv wasi-sdk-15.0/* /opt/wasi-sdk/
 	sudo rm -rf wasi-sdk-*
-	
-	curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
-	echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
-	sudo apt-get update
-	sudo apt-get install redis
-	which redis-server
 
 .PHONY: install-deps-macos
 install-deps-macos:

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ install-deps:
 	sudo mv wasi-sdk-15.0/* /opt/wasi-sdk/
 	sudo rm -rf wasi-sdk-*
 
+	curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+	echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+	sudo apt-get update
+	sudo apt-get install redis
+
 .PHONY: install-deps-macos
 install-deps-macos:
 	set -x
@@ -46,6 +51,7 @@ install-deps-macos:
 	sudo rm -rf wasi-sdk-*
 	chmod +x /opt/wasi-sdk/bin/clang
 	brew install openssl
+	brew install redis
 
 .PHONY: install-deps-win
 install-deps-win:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,12 @@ install-deps:
 	sudo mkdir -p /opt/wasi-sdk
 	sudo mv wasi-sdk-15.0/* /opt/wasi-sdk/
 	sudo rm -rf wasi-sdk-*
-	brew install redis
+	
+	curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+	echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+	sudo apt-get update
+	sudo apt-get install redis
+	which redis-server
 
 .PHONY: install-deps-macos
 install-deps-macos:

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,12 @@ install-deps:
 	sudo mv wasi-sdk-15.0/* /opt/wasi-sdk/
 	sudo rm -rf wasi-sdk-*
 
-	sudo apt install lsb-release
-	curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
-	echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
-	sudo apt-get update
-	sudo apt-get install redis
+	wget https://download.redis.io/redis-stable.tar.gz
+
+	tar -xzvf redis-stable.tar.gz
+	cd redis-stable
+	make
+	make install
 
 .PHONY: install-deps-macos
 install-deps-macos:

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,8 @@ install-deps:
 	sudo mkdir -p /opt/wasi-sdk
 	sudo mv wasi-sdk-15.0/* /opt/wasi-sdk/
 	sudo rm -rf wasi-sdk-*
-
-	wget https://download.redis.io/redis-stable.tar.gz
-
-	tar -xzvf redis-stable.tar.gz && cd redis-stable && make && make install
+	brew install redis
+	export PATH="/home/linuxbrew/.linuxbrew/opt/redis/bin:$$PATH"
 
 .PHONY: install-deps-macos
 install-deps-macos:

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,7 @@ install-deps:
 
 	wget https://download.redis.io/redis-stable.tar.gz
 
-	tar -xzvf redis-stable.tar.gz
-	cd redis-stable
-	make
-	make install
+	tar -xzvf redis-stable.tar.gz && cd redis-stable && make && make install
 
 .PHONY: install-deps-macos
 install-deps-macos:

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ install-deps:
 	sudo mv wasi-sdk-15.0/* /opt/wasi-sdk/
 	sudo rm -rf wasi-sdk-*
 
+	sudo apt install lsb-release
+	curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+	echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+	sudo apt-get update
+	sudo apt-get install redis
+
 .PHONY: install-deps-macos
 install-deps-macos:
 	set -x

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -137,11 +137,9 @@ stages:
           #     BUILD_ARCH: $(target_arch)
 
           # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#notes
-          - script: $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-            displayName: add brew to path
-            condition: and(succeeded(), eq(variables['target_os'], 'linux'))
-
-          - script: make install-deps
+          - script: |
+              $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
+              make install-deps
             displayName: Install build tools on linux
             condition: and(succeeded(), eq(variables['target_os'], 'linux'))
             env:

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -144,6 +144,13 @@ stages:
             condition: and(succeeded(), eq(variables['target_os'], 'linux'))
             env:
               BUILD_ARCH: $(target_arch)
+          
+          - script: |
+              redis-server --version
+            displayName: Smoke test redis-server cli in the path
+            condition: and(succeeded(), eq(variables['target_os'], 'linux'))
+            env:
+              BUILD_ARCH: $(target_arch)
 
           - script: make install-deps-macos
             displayName: Install build tools on macos

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -146,7 +146,7 @@ stages:
               BUILD_ARCH: $(target_arch)
           
           - script: |
-              redis-server --version
+              /home/linuxbrew/.linuxbrew/opt/redis/bin/redis-server --version
             displayName: Smoke test redis-server cli in the path
             condition: and(succeeded(), eq(variables['target_os'], 'linux'))
             env:

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -137,9 +137,7 @@ stages:
           #     BUILD_ARCH: $(target_arch)
 
           # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#notes
-          - script: |
-              eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-              make install-deps
+          - script: make install-deps
             displayName: Install build tools on linux
             condition: and(succeeded(), eq(variables['target_os'], 'linux'))
             env:

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -144,13 +144,6 @@ stages:
             condition: and(succeeded(), eq(variables['target_os'], 'linux'))
             env:
               BUILD_ARCH: $(target_arch)
-          
-          - script: |
-              /home/linuxbrew/.linuxbrew/opt/redis/bin/redis-server --version
-            displayName: Smoke test redis-server cli in the path
-            condition: and(succeeded(), eq(variables['target_os'], 'linux'))
-            env:
-              BUILD_ARCH: $(target_arch)
 
           - script: make install-deps-macos
             displayName: Install build tools on macos

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -136,14 +136,7 @@ stages:
           #   env:
           #     BUILD_ARCH: $(target_arch)
 
-          # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#notes
-          - name: "Install Redis"
-            uses: shogo82148/actions-setup-redis@v1
-            condition: and(succeeded(), eq(variables['target_os'], 'linux'))
-            with:
-              redis-version: '6.x'
-              auto-start: "false"
-            
+          # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#notes            
           - script: make install-deps
             displayName: Install build tools on linux
             condition: and(succeeded(), eq(variables['target_os'], 'linux'))

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -136,8 +136,10 @@ stages:
           #   env:
           #     BUILD_ARCH: $(target_arch)
 
-          # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#notes            
-          - script: make install-deps
+          # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#notes
+          - script: |
+              eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+              make install-deps
             displayName: Install build tools on linux
             condition: and(succeeded(), eq(variables['target_os'], 'linux'))
             env:

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -137,6 +137,13 @@ stages:
           #     BUILD_ARCH: $(target_arch)
 
           # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#notes
+          - name: "Install Redis"
+            uses: shogo82148/actions-setup-redis@v1
+            condition: and(succeeded(), eq(variables['target_os'], 'linux'))
+            with:
+              redis-version: '6.x'
+              auto-start: "false"
+            
           - script: make install-deps
             displayName: Install build tools on linux
             condition: and(succeeded(), eq(variables['target_os'], 'linux'))

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -144,6 +144,12 @@ stages:
             condition: and(succeeded(), eq(variables['target_os'], 'linux'))
             env:
               BUILD_ARCH: $(target_arch)
+          
+          - script: which /home/linuxbrew/.linuxbrew/opt/redis/bin/redis-server
+            displayName: Check redis-server exists
+            condition: and(succeeded(), eq(variables['target_os'], 'linux'))
+            env:
+              BUILD_ARCH: $(target_arch)
 
           - script: make install-deps-macos
             displayName: Install build tools on macos

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -112,12 +112,6 @@ stages:
             displayName: cache cargo registry 
             # condition: and(succeeded(), ne(variables['target_os'], 'windows'))   
 
-          #
-          # Environment variable updates
-          #
-          - bash: |
-              echo "todo"
-            displayName: Update build environment variables
 
           #
           # Update build environment
@@ -141,7 +135,12 @@ stages:
           #   condition: and(succeeded(), eq(variables['target_os'], 'windows'))
           #   env:
           #     BUILD_ARCH: $(target_arch)
-          
+
+          # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#notes
+          - script: $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
+            displayName: add brew to path
+            condition: and(succeeded(), eq(variables['target_os'], 'linux'))
+
           - script: make install-deps
             displayName: Install build tools on linux
             condition: and(succeeded(), eq(variables['target_os'], 'linux'))

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -138,7 +138,7 @@ stages:
 
           # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#notes
           - script: |
-              $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
+              eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
               make install-deps
             displayName: Install build tools on linux
             condition: and(succeeded(), eq(variables['target_os'], 'linux'))

--- a/crates/kv/src/implementors/redis.rs
+++ b/crates/kv/src/implementors/redis.rs
@@ -21,7 +21,10 @@ impl RedisImplementor {
         let connection_string = get_from_state("REDIS_ADDRESS", slight_state).unwrap();
         let client = redis::Client::open(connection_string).unwrap();
         let container_name = name.to_string();
-        Self { client, container_name }
+        Self {
+            client,
+            container_name,
+        }
     }
 
     pub fn get(&self, key: &str) -> Result<Vec<u8>> {

--- a/crates/kv/src/implementors/redis.rs
+++ b/crates/kv/src/implementors/redis.rs
@@ -47,6 +47,11 @@ impl RedisImplementor {
     pub fn keys(&self) -> Result<Vec<String>> {
         let mut con = self.client.get_connection()?;
         let keys: Vec<String> = con.keys(format!("{}:*", self.container_name))?;
+        // remove prefix
+        let keys: Vec<String> = keys
+            .iter()
+            .map(|k| k.replace(format!("{}:", self.container_name).as_str(), ""))
+            .collect();
         Ok(keys)
     }
 

--- a/tests/configs-test/usersecrets_slightfile.toml
+++ b/tests/configs-test/usersecrets_slightfile.toml
@@ -2,7 +2,7 @@ specversion = "0.1"
 
 [[secret_settings]]
 name = "key"
-value = "m-_gIgcT"
+value = "yczdTsRI"
 
 [[capability]]
 name = "configs.usersecrets"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -108,13 +108,10 @@ mod integration_tests {
             let binary_path = "redis-server";
             let output = Command::new("which")
                 .arg(binary_path)
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
                 .output()
                 .expect("failed to execute process");
 
-            let code = output.status.code().expect("should have status code");
-            if code != 0 {
+            if !output.status.success() {
                 let _binary_path = "/home/linuxbrew/.linuxbrew/opt/redis/bin/redis-server";
             }
             

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -105,7 +105,7 @@ mod integration_tests {
             let port = get_random_port();
 
             // make sure redis-server is running
-            let mut binary_path = "redis-server";
+            let binary_path = "redis-server";
             let output = Command::new("which")
                 .arg(binary_path)
                 .stdout(std::process::Stdio::piped())
@@ -115,7 +115,7 @@ mod integration_tests {
 
             let code = output.status.code().expect("should have status code");
             if code != 0 {
-                let binary_path = "/home/linuxbrew/.linuxbrew/opt/redis/bin/redis-server";
+                let _binary_path = "/home/linuxbrew/.linuxbrew/opt/redis/bin/redis-server";
             }
             
             let mut cmd = Command::new(binary_path)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -105,8 +105,9 @@ mod integration_tests {
             let port = get_random_port();
 
             // make sure redis-server is running
+            let mut binary_path = "redis-server";
             let output = Command::new("which")
-                .arg("redis-server")
+                .arg(binary_path)
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
                 .output()
@@ -114,10 +115,10 @@ mod integration_tests {
 
             let code = output.status.code().expect("should have status code");
             if code != 0 {
-                panic!("redis-server is not installed");
+                let binary_path = "/home/linuxbrew/.linuxbrew/opt/redis/bin/redis-server";
             }
-
-            let mut cmd = Command::new("redis-server")
+            
+            let mut cmd = Command::new(binary_path)
                 .args(["--port", port.to_string().as_str()])
                 .spawn()?;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -66,6 +66,8 @@ mod integration_tests {
 
     #[cfg(test)]
     mod kv_tests {
+        use std::{process::Command, net::{TcpListener, SocketAddrV4, Ipv4Addr}, env};
+
         use crate::{run, SLIGHT};
         use anyhow::Result;
 
@@ -90,6 +92,34 @@ mod integration_tests {
             let file_config = "./tests/kv-test/kvawsdynamodb_slightfile.toml";
             run(SLIGHT, vec!["-c", file_config, "run", "-m", KV_TEST_MODULE]);
             Ok(())
+        }
+
+        #[test]
+        fn redis_test() -> Result<()> {
+            // make sure redis server is running
+            let port = get_random_port();
+            let mut cmd = Command::new("redis-server")
+                .args(&["--port", port.to_string().as_str()])
+                .spawn()?;
+            
+            // sleep 5 seconds waiting for redis server to start
+            std::thread::sleep(std::time::Duration::from_secs(5));
+
+            let file_config = "./tests/kv-test/kvredis_slightfile.toml";
+            env::set_var("REDIS_ADDRESS", format!("redis://127.0.0.1:{}", port));
+            run(SLIGHT, vec!["-c", file_config, "run", "-m", KV_TEST_MODULE]);
+
+            // kill the server
+            cmd.kill()?;
+            Ok(())
+        }
+
+        fn get_random_port() -> u16 {
+            TcpListener::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+                .expect("Unable to bind to check for port")
+                .local_addr()
+                .unwrap()
+                .port()
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -66,7 +66,11 @@ mod integration_tests {
 
     #[cfg(test)]
     mod kv_tests {
-        use std::{process::Command, net::{TcpListener, SocketAddrV4, Ipv4Addr}, env};
+        use std::{
+            env,
+            net::{Ipv4Addr, SocketAddrV4, TcpListener},
+            process::Command,
+        };
 
         use crate::{run, SLIGHT};
         use anyhow::Result;
@@ -101,7 +105,7 @@ mod integration_tests {
             let mut cmd = Command::new("redis-server")
                 .args(&["--port", port.to_string().as_str()])
                 .spawn()?;
-            
+
             // sleep 5 seconds waiting for redis server to start
             std::thread::sleep(std::time::Duration::from_secs(5));
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -103,6 +103,20 @@ mod integration_tests {
         fn redis_test() -> Result<()> {
             // make sure redis server is running
             let port = get_random_port();
+
+            // make sure redis-server is running
+            let mut output = Command::new("which")
+                .arg("redis-server")
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .output()
+                .expect("failed to execute process");
+            
+            let code = output.status.code().expect("should have status code");
+            if code != 0 {
+                panic!("redis-server is not installed");
+            }
+
             let mut cmd = Command::new("redis-server")
                 .args(&["--port", port.to_string().as_str()])
                 .spawn()?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -105,16 +105,23 @@ mod integration_tests {
             let port = get_random_port();
 
             // make sure redis-server is running
-            let binary_path = "redis-server";
+            let mut binary_path = "redis-server";
             let output = Command::new("which")
                 .arg(binary_path)
                 .output()
                 .expect("failed to execute process");
 
             if !output.status.success() {
-                let _binary_path = "/home/linuxbrew/.linuxbrew/opt/redis/bin/redis-server";
+                binary_path = "/home/linuxbrew/.linuxbrew/opt/redis/bin/redis-server";
+                let output = Command::new("which")
+                    .arg(binary_path)
+                    .output()
+                    .expect("failed to execute process");
+                if !output.status.success() {
+                    panic!("redis-server not found");
+                }
             }
-            
+
             let mut cmd = Command::new(binary_path)
                 .args(["--port", port.to_string().as_str()])
                 .spawn()?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -105,20 +105,20 @@ mod integration_tests {
             let port = get_random_port();
 
             // make sure redis-server is running
-            let mut output = Command::new("which")
+            let output = Command::new("which")
                 .arg("redis-server")
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
                 .output()
                 .expect("failed to execute process");
-            
+
             let code = output.status.code().expect("should have status code");
             if code != 0 {
                 panic!("redis-server is not installed");
             }
 
             let mut cmd = Command::new("redis-server")
-                .args(&["--port", port.to_string().as_str()])
+                .args(["--port", port.to_string().as_str()])
                 .spawn()?;
 
             // sleep 5 seconds waiting for redis server to start

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -99,6 +99,7 @@ mod integration_tests {
         }
 
         #[test]
+        #[cfg(unix)] // Redis is not available on Windows: https://redis.io/docs/getting-started/installation/install-redis-on-windows/
         fn redis_test() -> Result<()> {
             // make sure redis server is running
             let port = get_random_port();

--- a/tests/kv-test/kvredis_slightfile.toml
+++ b/tests/kv-test/kvredis_slightfile.toml
@@ -1,0 +1,5 @@
+specversion = "0.1"
+secret_store = "configs.envvars"
+
+[[capability]]
+name = "kv.redis"


### PR DESCRIPTION
This PR adds the missing integration tests to the KV Redis resource. In fact, I found a bug in the previous redis implementation #187 that didn't use the `name` parameter in `open` at all. I used it and the key to form a compound key `name:key` which will differentiate one container name from another. 

The integration tests will only be run on UNIX OSs because Redis currently does not support Windows. 