### PR TITLE
feat: change path of type `&str` to type `AsRef<Path>`

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use anyhow::Result;
 use as_any::AsAny;
 
@@ -17,15 +19,15 @@ use slight_http_api::HttpHandlerData;
 pub struct BasicState {
     pub resource_map: ResourceMap,
     pub secret_store: String,
-    pub slightfile_path: String,
+    pub slightfile_path: PathBuf,
 }
 
 impl BasicState {
-    pub fn new(resource_map: ResourceMap, secret_store: &str, slightfile_path: &str) -> Self {
+    pub fn new(resource_map: ResourceMap, secret_store: &str, slightfile_path: impl AsRef<Path>) -> Self {
         Self {
             resource_map,
             secret_store: secret_store.to_string(),
-            slightfile_path: slightfile_path.to_string(),
+            slightfile_path: slightfile_path.as_ref().to_owned(),
         }
     }
 }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -23,7 +23,11 @@ pub struct BasicState {
 }
 
 impl BasicState {
-    pub fn new(resource_map: ResourceMap, secret_store: &str, slightfile_path: impl AsRef<Path>) -> Self {
+    pub fn new(
+        resource_map: ResourceMap,
+        secret_store: &str,
+        slightfile_path: impl AsRef<Path>,
+    ) -> Self {
         Self {
             resource_map,
             secret_store: secret_store.to_string(),

--- a/crates/http-api/src/lib.rs
+++ b/crates/http-api/src/lib.rs
@@ -204,7 +204,7 @@ mod unittests {
 
         let (parts, body) = req.into_parts();
         let headers: HttpHeader = (&parts.headers).into();
-        let uri = &(&parts.uri).to_string();
+        let uri = parts.uri.to_string();
         let method: Method = (&parts.method).into();
         let bytes: HttpBody = HttpBody::from_body(body).await?;
         let params = [];

--- a/crates/http-api/src/lib.rs
+++ b/crates/http-api/src/lib.rs
@@ -210,7 +210,7 @@ mod unittests {
         let params = [];
         let req = Request {
             method,
-            uri,
+            uri: &uri,
             headers: &headers.0,
             params: &params,
             body: Some(&bytes.0),

--- a/crates/http-handler-macro/src/lib.rs
+++ b/crates/http-handler-macro/src/lib.rs
@@ -82,7 +82,7 @@ pub fn register_handler(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // invoke wit-bindgen parsing
     let path: &Path = HTTP_WIT_PATH.as_ref();
     let parent = path.parent().unwrap();
-    let contents = std::fs::read_to_string(&path).unwrap();
+    let contents = std::fs::read_to_string(path).unwrap();
     let iface = Interface::parse_with(mod_name.clone(), &contents, |path| load_fs(parent, path))
         .expect("parse error");
     let mut files = Files::default();

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -309,7 +309,7 @@ async fn handler<T: Buildable + Send + Sync + 'static>(
     let headers: HttpHeader = (&parts.headers).into();
 
     let bytes = HttpBody::from_body(body).await?.inner();
-    let uri = &(&parts.uri).to_string();
+    let uri = &parts.uri.to_string();
     let req = Request {
         method,
         uri,

--- a/crates/runtime-configs/src/implementors/usersecrets.rs
+++ b/crates/runtime-configs/src/implementors/usersecrets.rs
@@ -44,7 +44,7 @@ impl UserSecrets {
 
         // decrypt key and return value
         let sc = ShortCrypt::new(encryption_key);
-        sc.decrypt_url_component(&value)
+        sc.decrypt_url_component(value)
             .map_err(|err| anyhow::anyhow!(err))
     }
 

--- a/crates/runtime-configs/src/implementors/usersecrets.rs
+++ b/crates/runtime-configs/src/implementors/usersecrets.rs
@@ -1,4 +1,4 @@
-use std::fs::OpenOptions;
+use std::{fs::OpenOptions, path::Path};
 
 use anyhow::{bail, Result};
 use short_crypt::ShortCrypt;
@@ -10,7 +10,7 @@ use spiderlightning::core::{
 pub struct UserSecrets;
 
 impl UserSecrets {
-    pub fn get(key: &str, toml_file_path: &str) -> Result<Vec<u8>> {
+    pub fn get(key: &str, toml_file_path: impl AsRef<Path>) -> Result<Vec<u8>> {
         // check if encryption key env var is present
         let encryption_key = if let Ok(s) = get_key() {
             s
@@ -48,7 +48,7 @@ impl UserSecrets {
             .map_err(|err| anyhow::anyhow!(err))
     }
 
-    pub fn set(key: &str, value: &[u8], toml_file_path: &str) -> Result<()> {
+    pub fn set(key: &str, value: &[u8], toml_file_path: impl AsRef<Path>) -> Result<()> {
         // call in to slight to handle config creation
         let toml_file_path = toml_file_path;
         let mut toml_file = OpenOptions::new()

--- a/crates/runtime-configs/src/lib.rs
+++ b/crates/runtime-configs/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod implementors;
 
+use std::path::Path;
+
 use anyhow::{Context, Result};
 use uuid::Uuid;
 
@@ -162,7 +164,7 @@ impl Default for ConfigsImplementor {
 }
 
 /// SDK-ish bit
-pub fn get(config_type: &str, key: &str, toml_file_path: &str) -> Result<Vec<u8>> {
+pub fn get(config_type: &str, key: &str, toml_file_path: impl AsRef<Path>) -> Result<Vec<u8>> {
     match config_type.into() {
         ConfigsImplementor::EnvVars => Ok(EnvVars::get(key)?),
         ConfigsImplementor::UserSecrets => Ok(UserSecrets::get(key, toml_file_path)?),
@@ -170,7 +172,7 @@ pub fn get(config_type: &str, key: &str, toml_file_path: &str) -> Result<Vec<u8>
     }
 }
 
-pub fn set(config_type: &str, key: &str, value: &[u8], toml_file_path: &str) -> Result<()> {
+pub fn set(config_type: &str, key: &str, value: &[u8], toml_file_path: impl AsRef<Path>) -> Result<()> {
     match config_type.into() {
         ConfigsImplementor::EnvVars => Ok(EnvVars::set(key, value)?),
         ConfigsImplementor::UserSecrets => Ok(UserSecrets::set(key, value, toml_file_path)?),

--- a/crates/runtime-configs/src/lib.rs
+++ b/crates/runtime-configs/src/lib.rs
@@ -172,7 +172,12 @@ pub fn get(config_type: &str, key: &str, toml_file_path: impl AsRef<Path>) -> Re
     }
 }
 
-pub fn set(config_type: &str, key: &str, value: &[u8], toml_file_path: impl AsRef<Path>) -> Result<()> {
+pub fn set(
+    config_type: &str,
+    key: &str,
+    value: &[u8],
+    toml_file_path: impl AsRef<Path>,
+) -> Result<()> {
     match config_type.into() {
         ConfigsImplementor::EnvVars => Ok(EnvVars::set(key, value)?),
         ConfigsImplementor::UserSecrets => Ok(UserSecrets::set(key, value, toml_file_path)?),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod ctx;
 pub mod resource;
 
+use std::path::Path;
+
 use anyhow::Result;
 use ctx::{SlightCtx, SlightCtxBuilder};
 use resource::{EventsData, HttpData, Linkable};
@@ -54,7 +56,7 @@ pub struct Builder {
 
 impl Builder {
     /// Create a new runtime builder.
-    pub fn new_default(module: &str) -> Result<Self> {
+    pub fn new_default(module: impl AsRef<Path>) -> Result<Self> {
         let engine = Engine::new(&default_config()?)?;
         let mut linker = Linker::new(&engine);
         linker.allow_shadowing(true);

--- a/slight/src/commands/run.rs
+++ b/slight/src/commands/run.rs
@@ -1,4 +1,7 @@
-use std::{sync::{Arc, Mutex}, path::Path};
+use std::{
+    path::Path,
+    sync::{Arc, Mutex},
+};
 
 use anyhow::{bail, Result};
 use as_any::Downcast;

--- a/slight/src/commands/run.rs
+++ b/slight/src/commands/run.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::{sync::{Arc, Mutex}, path::Path};
 
 use anyhow::{bail, Result};
 use as_any::Downcast;
@@ -26,7 +26,7 @@ const PUBSUB_HOST_IMPLEMENTORS: [&str; 2] = ["pubsub.confluent_apache_kafka", "p
 const CONFIGS_HOST_IMPLEMENTORS: [&str; 3] =
     ["configs.usersecrets", "configs.envvars", "configs.azapp"];
 
-pub async fn handle_run(module: &str, toml_file_path: &str) -> Result<()> {
+pub async fn handle_run(module: impl AsRef<Path>, toml_file_path: impl AsRef<Path>) -> Result<()> {
     let toml_file_contents = std::fs::read_to_string(&toml_file_path)?;
     let toml = toml::from_str::<TomlFile>(&toml_file_contents)?;
 
@@ -34,7 +34,7 @@ pub async fn handle_run(module: &str, toml_file_path: &str) -> Result<()> {
 
     let resource_map = Arc::new(Mutex::new(StateTable::default()));
 
-    let host_builder = build_store_instance(&toml, toml_file_path, resource_map.clone(), module)?;
+    let host_builder = build_store_instance(&toml, &toml_file_path, resource_map.clone(), &module)?;
     let (mut store, instance) = host_builder.build()?;
 
     let caps = toml.capability.as_ref().unwrap();
@@ -47,7 +47,7 @@ pub async fn handle_run(module: &str, toml_file_path: &str) -> Result<()> {
     if events_enabled {
         log::debug!("Events capability enabled");
         let guest_builder =
-            build_store_instance(&toml, toml_file_path, resource_map.clone(), module)?;
+            build_store_instance(&toml, &toml_file_path, resource_map.clone(), &module)?;
         let event_handler_resource: &mut Events<Builder> = get_resource(&mut store, "events");
         event_handler_resource.update_state(slight_common::Builder::new(guest_builder))?;
     }
@@ -55,12 +55,11 @@ pub async fn handle_run(module: &str, toml_file_path: &str) -> Result<()> {
     if http_enabled {
         log::debug!("Http capability enabled");
         let guest_builder: Builder =
-            build_store_instance(&toml, toml_file_path, resource_map.clone(), module)?;
+            build_store_instance(&toml, &toml_file_path, resource_map.clone(), &module)?;
         let http_api_resource: &mut Http<Builder> = get_resource(&mut store, "http");
         http_api_resource.update_state(slight_common::Builder::new(guest_builder))?;
     }
 
-    tracing::info!("Executing {}", module);
     instance
         .get_typed_func::<(), _, _>(&mut store, "_start")?
         .call(&mut store, ())?;
@@ -107,9 +106,9 @@ async fn shutdown_signal() {
 
 fn build_store_instance(
     toml: &TomlFile,
-    toml_file_path: &str,
+    toml_file_path: impl AsRef<Path>,
     resource_map: Arc<Mutex<StateTable>>,
-    module: &str,
+    module: impl AsRef<Path>,
 ) -> Result<Builder> {
     let mut builder = Builder::new_default(module)?;
     let mut slight_builder = SlightCtxBuilder::default();
@@ -131,7 +130,7 @@ fn build_store_instance(
                         slight_builder =
                             slight_builder.add_state(State::Kv(slight_kv::KvState::new(
                                 resource_type.to_string(),
-                                BasicState::new(resource_map.clone(), ss, toml_file_path),
+                                BasicState::new(resource_map.clone(), ss, &toml_file_path),
                             )))?;
                     } else {
                         bail!("the kv capability requires a secret store of some type (i.e., envvars, or usersecrets) specified in your config file so it knows where to grab, say, the AZURE_STORAGE_ACCOUNT, and AZURE_STORAGE_KEY from.")
@@ -142,7 +141,7 @@ fn build_store_instance(
                         builder.link_capability::<Mq>("mq".to_string())?;
                         slight_builder = slight_builder.add_state(State::Mq(MqState::new(
                             resource_type.to_string(),
-                            BasicState::new(resource_map.clone(), ss, toml_file_path),
+                            BasicState::new(resource_map.clone(), ss, &toml_file_path),
                         )))?;
                     } else {
                         bail!("the mq capability requires a secret store of some type (i.e., envvars, or usersecrets) specified in your config file so it knows where to grab the AZURE_SERVICE_BUS_NAMESPACE, AZURE_POLICY_NAME, and AZURE_POLICY_KEY from.")
@@ -154,7 +153,7 @@ fn build_store_instance(
                         slight_builder =
                             slight_builder.add_state(State::Lockd(LockdState::new(
                                 resource_type.to_string(),
-                                BasicState::new(resource_map.clone(), ss, toml_file_path),
+                                BasicState::new(resource_map.clone(), ss, &toml_file_path),
                             )))?;
                     } else {
                         bail!("the lockd capability requires a secret store of some type (i.e., envvars, or usersecrets) specified in your config file so it knows where to grab the ETCD_ENDPOINT.")
@@ -166,7 +165,7 @@ fn build_store_instance(
                         slight_builder =
                             slight_builder.add_state(State::PubSub(PubsubState::new(
                                 resource_type.to_string(),
-                                BasicState::new(resource_map.clone(), ss, toml_file_path),
+                                BasicState::new(resource_map.clone(), ss, &toml_file_path),
                             )))?;
                     } else {
                         bail!("the pubsub capability requires a secret store of some type (i.e., envvars, or usersecrets) specified in your config file so it knows where to grab the CAK_SECURITY_PROTOCOL, CAK_SASL_MECHANISMS, CAK_SASL_USERNAME, CAK_SASL_PASSWORD, and CAK_GROUP_ID from.")
@@ -176,7 +175,7 @@ fn build_store_instance(
                     builder.link_capability::<Configs>("configs".to_string())?;
                     slight_builder = slight_builder.add_state(State::RtCfg(ConfigsState::new(
                         resource_type.to_string(),
-                        BasicState::new(resource_map.clone(), "", toml_file_path),
+                        BasicState::new(resource_map.clone(), "", &toml_file_path),
                     )))?;
                 }
                 "http" => {

--- a/slight/src/commands/secret.rs
+++ b/slight/src/commands/secret.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use spiderlightning::core::{secret::create_secret, slightfile::TomlFile};
-use std::fs::OpenOptions;
+use std::{fs::OpenOptions, path::Path};
 
-pub fn handle_secret(key: &str, value: &str, toml_file_path: &str) -> Result<()> {
+pub fn handle_secret(key: &str, value: &str, toml_file_path: impl AsRef<Path>) -> Result<()> {
     let mut toml_file = OpenOptions::new()
         .read(true)
         .write(true)

--- a/src/core/secret.rs
+++ b/src/core/secret.rs
@@ -114,7 +114,7 @@ mod unittests {
             .read(true)
             .write(true)
             .create(true)
-            .open(&toml_file_pathstr)?;
+            .open(toml_file_pathstr)?;
 
         assert!(create_secret("key", "value", &mut tmp_toml, &mut toml_file).is_ok());
 
@@ -143,7 +143,7 @@ mod unittests {
             .read(true)
             .write(true)
             .create(true)
-            .open(&toml_file_pathstr)?;
+            .open(toml_file_pathstr)?;
 
         toml_file.write_all(toml::to_string(&tmp_toml)?.as_bytes())?;
         create_secret("baz", "baz_val_encrypted", &mut tmp_toml, &mut toml_file)?;
@@ -196,7 +196,7 @@ mod unittests {
             .read(true)
             .write(true)
             .create(true)
-            .open(&toml_file_pathstr)?;
+            .open(toml_file_pathstr)?;
 
         toml_file.write_all(toml::to_string(&tmp_toml)?.as_bytes())?;
         create_secret("foo", "foo_val_encrypted", &mut tmp_toml, &mut toml_file)?;
@@ -242,7 +242,7 @@ mod unittests {
             .read(true)
             .write(true)
             .create(true)
-            .open(&toml_file_pathstr)?;
+            .open(toml_file_pathstr)?;
 
         toml_file.write_all(toml::to_string(&tmp_toml)?.as_bytes())?;
         create_secret("foo", "foo_val_encrypted", &mut tmp_toml, &mut toml_file)?;

--- a/tests/configs-test/usersecrets_slightfile.toml
+++ b/tests/configs-test/usersecrets_slightfile.toml
@@ -2,7 +2,7 @@ specversion = "0.1"
 
 [[secret_settings]]
 name = "key"
-value = "JD3jTiQk"
+value = "yczdTsRI"
 
 [[capability]]
 name = "configs.usersecrets"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -115,7 +115,7 @@ mod integration_tests {
         async fn http_test() -> Result<()> {
             let config = "./tests/http-test/slightfile.toml";
             let mut child = Command::new(SLIGHT)
-                .args(&["-c", config, "run", "-m", HTTP_TEST_MODULE])
+                .args(["-c", config, "run", "-m", HTTP_TEST_MODULE])
                 .spawn()?;
             sleep(Duration::from_secs(2)).await;
 


### PR DESCRIPTION
In library design, it is more versatile to use `AsRef<Path>` to abstract any path types. Thie allow the caller to path `Path`, `PathBuf`, `&str` or `String`.

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>