### PR TITLE
fix(http): Removed block_on on http body parsing

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -57,7 +57,7 @@ pub trait Ctx {
 
 /// A trait for builder
 pub trait Buildable: Clone {
-    type Ctx: Ctx;
+    type Ctx: Ctx + Send + Sync;
 
     fn build(&self) -> (Store<Self::Ctx>, Instance);
 }

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -308,10 +308,7 @@ async fn handler<T: Buildable + Send + Sync + 'static>(
     let method: Method = (&parts.method).into();
     let headers: HttpHeader = (&parts.headers).into();
 
-    // FIXME: `HttpBody::from_body` returns a future here. The reason that `block_on` is used is
-    // because the `store` and `instance` are holding a mutex, which means that the async runtime
-    // cannot switch to another thread.
-    let bytes = block_on(HttpBody::from_body(body))?.inner();
+    let bytes = HttpBody::from_body(body).await?.inner();
     let uri = &(&parts.uri).to_string();
     let req = Request {
         method,


### PR DESCRIPTION
The comment that explained why there was a `block_on` on http body parsing was no longer applicable, since #175 removed the lock on store and instance, instead creates them for each http request. 

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>