### PR TITLE
implemented add command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ target/
 bindings.rs
 .idea
 .DS_Store
-
+**.tar.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3638,6 +3638,7 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
+ "reqwest",
  "slight-common",
  "slight-events",
  "slight-events-api",

--- a/slight/Cargo.toml
+++ b/slight/Cargo.toml
@@ -34,6 +34,7 @@ toml = "0.5"
 as-any = "0.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1", features = ["log"] }
+reqwest = "0.11"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/slight/src/commands/add.rs
+++ b/slight/src/commands/add.rs
@@ -1,0 +1,84 @@
+use std::{
+    fs::{create_dir_all, remove_dir_all, File},
+    io::{self, ErrorKind},
+};
+
+use anyhow::Result;
+
+const GITHUB_URL: &str = "https://github.com/deislabs/spiderlightning/releases/download";
+
+const KV_DOWNLOADS: [&str; 3] = ["kv", "types", "resources"];
+const CONFIGS_DOWNLOADS: [&str; 2] = ["configs", "types"];
+const EVENTS_DOWNLOADS: [&str; 4] = ["events", "event-handler", "types", "resources"];
+const HTTP_DOWNLOADS: [&str; 4] = ["http", "http-handler", "http-types", "types"];
+const LOCKD_DOWNLOADS: [&str; 3] = ["lockd", "types", "resources"];
+const MQ_DOWNLOADS: [&str; 3] = ["mq", "types", "resources"];
+const PUBSUB_DOWNLOADS: [&str; 3] = ["pubsub", "types", "resources"];
+
+pub async fn handle_add(what_to_add: &str) -> Result<()> {
+    let (interface, release, folder_name) = if !what_to_add.contains('@') {
+        panic!("invalid use: to download an interface, say `slight add <interface-name>@<release-tag>`");
+        // TODO: In the future, let's support omitting the release tag to download the latest release
+    } else {
+        let find_at = what_to_add.find('@').unwrap();
+        // ^^^ fine to unwrap, we are guaranteed to have a '@' at this point.
+        (
+            &what_to_add[..find_at],
+            &what_to_add[find_at + 1..],
+            what_to_add.replace('@', "_"),
+        )
+    };
+
+    match what_to_add {
+        _ if interface.eq("kv")
+            | interface.eq("configs")
+            | interface.eq("events")
+            | interface.eq("http")
+            | interface.eq("lockd")
+            | interface.eq("mq")
+            | interface.eq("pubsub") =>
+        {
+            maybe_recreate_dir(&folder_name)?;
+            for i in get_interface_downloads_by_name(interface) {
+                let resp = reqwest::get(format!("{}/{}/{}.wit", GITHUB_URL, release, i))
+                    .await?
+                    .text()
+                    .await?;
+                let mut out = File::create(format!("{}/{}.wit", folder_name, i))?;
+                io::copy(&mut resp.as_bytes(), &mut out)?;
+            }
+        }
+        _ => {
+            panic!("invalid interface name (1): currently, slight only supports the download of 'configs', 'events', 'kv', 'mq', 'lockd', 'pubsub', and 'http'.")
+        }
+    }
+    Ok(())
+}
+
+fn maybe_recreate_dir(dir_name: &str) -> Result<()> {
+    match remove_dir_all(dir_name) {
+        Err(e) if e.kind() != ErrorKind::NotFound => {
+            panic!("{}", e);
+        }
+        _ => {
+            create_dir_all(dir_name)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn get_interface_downloads_by_name(name: &str) -> Vec<&str> {
+    match name {
+        _ if name.eq("kv") => KV_DOWNLOADS.to_vec(),
+        _ if name.eq("configs") => CONFIGS_DOWNLOADS.to_vec(),
+        _ if name.eq("events") => EVENTS_DOWNLOADS.to_vec(),
+        _ if name.eq("http") => HTTP_DOWNLOADS.to_vec(),
+        _ if name.eq("lockd") => LOCKD_DOWNLOADS.to_vec(),
+        _ if name.eq("mq") => MQ_DOWNLOADS.to_vec(),
+        _ if name.eq("pubsub") => PUBSUB_DOWNLOADS.to_vec(),
+        _ => {
+            panic!("invalid interface name (2): currently, slight only supports the download of 'configs', 'events', 'kv', 'mq', 'lockd', 'pubsub', and 'http'.")
+        }
+    }
+}

--- a/slight/src/commands/mod.rs
+++ b/slight/src/commands/mod.rs
@@ -1,2 +1,3 @@
+pub mod add;
 pub mod run;
 pub mod secret;

--- a/slight/src/main.rs
+++ b/slight/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use slight_lib::commands::{run::handle_run, secret::handle_secret};
+use slight_lib::commands::{add::handle_add, run::handle_run, secret::handle_secret};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
@@ -8,7 +8,7 @@ struct Args {
     #[clap(subcommand)]
     command: Commands,
     #[clap(short, long, value_parser)]
-    config: String,
+    config: Option<String>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -25,6 +25,11 @@ enum Commands {
         #[clap(short, long, value_parser)]
         value: String,
     },
+    /// Download a SpiderLightning interface
+    Add {
+        #[clap(short, long, value_parser)]
+        interface_at_release: String,
+    },
 }
 
 /// The entry point for slight CLI
@@ -37,7 +42,10 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     match &args.command {
-        Commands::Run { module } => handle_run(module, &args.config).await,
-        Commands::Secret { key, value } => handle_secret(key, value, &args.config),
+        Commands::Run { module } => handle_run(module, &args.config.unwrap()).await,
+        Commands::Secret { key, value } => handle_secret(key, value, &args.config.unwrap()),
+        Commands::Add {
+            interface_at_release,
+        } => handle_add(interface_at_release).await,
     }
 }


### PR DESCRIPTION
Here's how the interaction is looking:
![image](https://user-images.githubusercontent.com/39843321/193338656-e3d3e838-62ff-4568-bffd-8cbde3fa30da.png)

The `add` command will pretty much just curl the wit file artifact (i.e., the interface, and its' dependencies) from a specific release tag and put it under a folder called `<capability_name>_<release_tag>`.

closes #35 

Signed-off-by: Dan Chiarlone <dchiarlone@microsoft.com>