### PR TITLE
feat: better error message for missing `wasm32-wasi 

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,18 +18,14 @@ fn main() {
     // Check if wasm32-wasi target is installed
     let target = "wasm32-wasi";
     let output = Command::new("rustup")
-        .args(&["target", "list", "--installed"])
+        .args(["target", "list", "--installed"])
         .output()
         .expect("failed to execute process");
     let output = std::str::from_utf8(&output.stdout).unwrap();
     if !output.lines().any(|line| line == target) {
-        writeln!(
-            stderr(),
-            "Error: {} target is not installed. Run `rustup target add {}`",
+        eprintln!("Error: {} target is not installed. Run `rustup target add {}`",
             target,
-            target
-        )
-        .unwrap();
+            target);
         std::process::exit(1);
     }
 

--- a/build.rs
+++ b/build.rs
@@ -23,9 +23,10 @@ fn main() {
         .expect("failed to execute process");
     let output = std::str::from_utf8(&output.stdout).unwrap();
     if !output.lines().any(|line| line == target) {
-        eprintln!("Error: {} target is not installed. Run `rustup target add {}`",
-            target,
-            target);
+        eprintln!(
+            "Error: {} target is not installed. Run `rustup target add {}`",
+            target, target
+        );
         std::process::exit(1);
     }
 

--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,7 @@ fn main() {
     println!("cargo:rerun-if-changed={}/src/main.rs", KV_TEST_PATH);
     println!("cargo:rerun-if-changed={}/src/main.rs", HTTP_TEST_PATH);
     println!("cargo:rerun-if-changed={}/src/main.rs", CONFIGS_TEST_PATH);
-    
+
     // Check if wasm32-wasi target is installed
     let target = "wasm32-wasi";
     let output = Command::new("rustup")
@@ -26,12 +26,13 @@ fn main() {
         writeln!(
             stderr(),
             "Error: {} target is not installed. Run `rustup target add {}`",
-            target, target
+            target,
+            target
         )
         .unwrap();
         std::process::exit(1);
     }
-    
+
     // Build test wasm modules
     cargo_wasi_build(KV_TEST_PATH);
     cargo_wasi_build(HTTP_TEST_PATH);

--- a/build.rs
+++ b/build.rs
@@ -9,11 +9,30 @@ const HTTP_TEST_PATH: &str = "tests/http-test";
 const CONFIGS_TEST_PATH: &str = "tests/configs-test";
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed={}", WIT_DIRECTORY);
     println!("cargo:rerun-if-changed={}/src/main.rs", KV_TEST_PATH);
     println!("cargo:rerun-if-changed={}/src/main.rs", HTTP_TEST_PATH);
     println!("cargo:rerun-if-changed={}/src/main.rs", CONFIGS_TEST_PATH);
-
+    
+    // Check if wasm32-wasi target is installed
+    let target = "wasm32-wasi";
+    let output = Command::new("rustup")
+        .args(&["target", "list", "--installed"])
+        .output()
+        .expect("failed to execute process");
+    let output = std::str::from_utf8(&output.stdout).unwrap();
+    if !output.lines().any(|line| line == target) {
+        writeln!(
+            stderr(),
+            "Error: {} target is not installed. Run `rustup target add {}`",
+            target, target
+        )
+        .unwrap();
+        std::process::exit(1);
+    }
+    
+    // Build test wasm modules
     cargo_wasi_build(KV_TEST_PATH);
     cargo_wasi_build(HTTP_TEST_PATH);
     cargo_wasi_build(CONFIGS_TEST_PATH);


### PR DESCRIPTION
added a better error message to deal with the case that wasm32-wasi target isn't installed when building

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>