### PR TITLE
feat(slight): better error message for slight new command

### DIFF
--- a/slight/src/commands/new.rs
+++ b/slight/src/commands/new.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail, Context};
 use flate2::bufread::GzDecoder;
 use std::io::Write;
 use std::{
@@ -23,13 +23,22 @@ pub async fn handle_new(name_at_release: &str, template: &Templates) -> Result<(
         (&name_at_release[..find_at], &name_at_release[find_at + 1..])
     };
 
+    // check project_name is not C or Rust
+    if project_name == "c" || project_name == "rust" {
+        bail!("project name cannot be c or rust");
+    }
+
     let resp = reqwest::get(format!(
         "https://github.com/deislabs/spiderlightning/releases/download/{}/{}-template.tar.gz",
         release, template
     ))
-    .await?
-    .bytes()
     .await?;
+    if resp.status() == 404 {
+        bail!("could not find template {} for release {}, pleases see all releases in https://github.com/deislabs/spiderlightning/releases", template, release);
+    }
+
+    let resp = resp.bytes().await?;
+
     Archive::new(GzDecoder::new(BufReader::new(resp.as_ref()))).unpack("./")?;
 
     match template {
@@ -54,8 +63,8 @@ fn setup_c_template(project_name: &str, release: &str) -> Result<()> {
     let mut makefile_f = File::create("./c/Makefile")?;
     write!(makefile_f, "{}", makefile_s)?;
     drop(makefile_f);
-
-    std::fs::rename("c", project_name)?;
+    
+    better_rename("c", project_name)?;
 
     Ok(())
 }
@@ -73,7 +82,15 @@ fn setup_rust_template(project_name: &str, release: &str) -> Result<()> {
     drop(cargo_f);
     drop(main_f);
 
-    std::fs::rename("rust", project_name)?;
+    better_rename("rust", project_name)?;
 
+    Ok(())
+}
+
+fn better_rename(from: &str, to: &str) -> Result<()> {
+    std::fs::rename(from, to).with_context(|| format!(
+        "could not create project: {}",
+        to
+    ))?;
     Ok(())
 }

--- a/slight/src/commands/new.rs
+++ b/slight/src/commands/new.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail, Context};
+use anyhow::{bail, Context, Result};
 use flate2::bufread::GzDecoder;
 use std::io::Write;
 use std::{
@@ -63,7 +63,7 @@ fn setup_c_template(project_name: &str, release: &str) -> Result<()> {
     let mut makefile_f = File::create("./c/Makefile")?;
     write!(makefile_f, "{}", makefile_s)?;
     drop(makefile_f);
-    
+
     better_rename("c", project_name)?;
 
     Ok(())
@@ -88,9 +88,6 @@ fn setup_rust_template(project_name: &str, release: &str) -> Result<()> {
 }
 
 fn better_rename(from: &str, to: &str) -> Result<()> {
-    std::fs::rename(from, to).with_context(|| format!(
-        "could not create project: {}",
-        to
-    ))?;
+    std::fs::rename(from, to).with_context(|| format!("could not create project: {}", to))?;
     Ok(())
 }


### PR DESCRIPTION
Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>

This PR makes the error messages for `slight new` command better in these cases:
1. a version that's not in the releases is given
2. there exists a file/directory of the same name
3. the project name is c or rust
#225 