### PR TITLE
improved error messages when failing to provide a correct slightfile

### DIFF
--- a/slight/src/commands/run.rs
+++ b/slight/src/commands/run.rs
@@ -25,8 +25,10 @@ const CONFIGS_HOST_IMPLEMENTORS: [&str; 3] =
     ["configs.usersecrets", "configs.envvars", "configs.azapp"];
 
 pub async fn handle_run(module: impl AsRef<Path>, toml_file_path: impl AsRef<Path>) -> Result<()> {
-    let toml_file_contents = std::fs::read_to_string(&toml_file_path).expect("could not locate slightfile");
-    let toml = toml::from_str::<TomlFile>(&toml_file_contents).expect("provided file is not a slightfile");
+    let toml_file_contents =
+        std::fs::read_to_string(&toml_file_path).expect("could not locate slightfile");
+    let toml =
+        toml::from_str::<TomlFile>(&toml_file_contents).expect("provided file is not a slightfile");
 
     tracing::info!("Starting slight");
 

--- a/slight/src/commands/run.rs
+++ b/slight/src/commands/run.rs
@@ -25,8 +25,8 @@ const CONFIGS_HOST_IMPLEMENTORS: [&str; 3] =
     ["configs.usersecrets", "configs.envvars", "configs.azapp"];
 
 pub async fn handle_run(module: impl AsRef<Path>, toml_file_path: impl AsRef<Path>) -> Result<()> {
-    let toml_file_contents = std::fs::read_to_string(&toml_file_path)?;
-    let toml = toml::from_str::<TomlFile>(&toml_file_contents)?;
+    let toml_file_contents = std::fs::read_to_string(&toml_file_path).expect("could not locate slightfile");
+    let toml = toml::from_str::<TomlFile>(&toml_file_contents).expect("provided file is not a slightfile");
 
     tracing::info!("Starting slight");
 


### PR DESCRIPTION
This closes #161 

When the provided file doesn't exist, we now get:
<img width="1197" alt="image" src="https://user-images.githubusercontent.com/39843321/207517821-9877f861-64f8-4010-bec3-d95aaed92aa1.png">

When the provided file isn't a correct slightfile, we now get:
<img width="1196" alt="image" src="https://user-images.githubusercontent.com/39843321/207517866-79e8791a-6c95-42ab-9621-0f15eaee6a65.png">

Signed-off-by: danbugs <danilochiarlone@gmail.com>