### PR TITLE
feat: renamed router http error to http-router-error

### DIFF
--- a/crates/http-handler-macro/src/lib.rs
+++ b/crates/http-handler-macro/src/lib.rs
@@ -114,6 +114,7 @@ pub fn register_handler(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #iface
 
         mod #internal_mod_ident {
+            use crate::*;
             use crate::#mod_ident::*;
             pub struct #struct_ident {}
             impl #trait_ident for #struct_ident {

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -21,8 +21,8 @@ use tracing::log;
 use slight_http_api::{HttpBody, HttpHandler, HttpHeader, Method, Request};
 
 wit_bindgen_wasmtime::export!("../../wit/http.wit");
-wit_error_rs::impl_error!(http::HttpError);
-wit_error_rs::impl_from!(anyhow::Error, http::HttpError::UnexpectedError);
+wit_error_rs::impl_error!(http::HttpRouterError);
+wit_error_rs::impl_from!(anyhow::Error, http::HttpRouterError::UnexpectedError);
 
 #[derive(Clone, Debug, Default)]
 enum Methods {
@@ -57,22 +57,22 @@ impl RouterInner {
     }
 
     /// Adds a new route with `GET` method and the handler's name.
-    fn get(&mut self, route: String, handler: String) -> Result<Self, http::HttpError> {
+    fn get(&mut self, route: String, handler: String) -> Result<Self, http::HttpRouterError> {
         self.add(route, handler, Methods::GET)
     }
 
     /// Adds a new route with `PUT` method and the handler's name.
-    fn put(&mut self, route: String, handler: String) -> Result<Self, http::HttpError> {
+    fn put(&mut self, route: String, handler: String) -> Result<Self, http::HttpRouterError> {
         self.add(route, handler, Methods::PUT)
     }
 
     /// Adds a new route with `POST` method and the handler's name.
-    fn post(&mut self, route: String, handler: String) -> Result<Self, http::HttpError> {
+    fn post(&mut self, route: String, handler: String) -> Result<Self, http::HttpRouterError> {
         self.add(route, handler, Methods::POST)
     }
 
     /// Adds a new route with `DELETE` method and the handler's name.
-    fn delete(&mut self, route: String, handler: String) -> Result<Self, http::HttpError> {
+    fn delete(&mut self, route: String, handler: String) -> Result<Self, http::HttpRouterError> {
         self.add(route, handler, Methods::DELETE)
     }
 
@@ -82,7 +82,7 @@ impl RouterInner {
         route: String,
         handler: String,
         method: Methods,
-    ) -> Result<Self, http::HttpError> {
+    ) -> Result<Self, http::HttpRouterError> {
         let route = Route {
             method,
             route,
@@ -99,7 +99,7 @@ pub struct ServerInner {
 }
 
 impl ServerInner {
-    fn close(self) -> Result<(), HttpError> {
+    fn close(self) -> Result<(), HttpRouterError> {
         let closer = self.closer.lock().unwrap();
         thread::scope(|s| {
             s.spawn(|_| {
@@ -151,11 +151,11 @@ impl<T: WasmtimeBuildable + Send + Sync + 'static> http::Http for Http<T> {
     type Router = RouterInner;
     type Server = ServerInner;
 
-    fn router_new(&mut self) -> Result<Self::Router, http::HttpError> {
+    fn router_new(&mut self) -> Result<Self::Router, http::HttpRouterError> {
         Ok(RouterInner::default())
     }
 
-    fn router_new_with_base(&mut self, base: &str) -> Result<Self::Router, http::HttpError> {
+    fn router_new_with_base(&mut self, base: &str) -> Result<Self::Router, http::HttpRouterError> {
         Ok(RouterInner::new(base))
     }
 
@@ -164,7 +164,7 @@ impl<T: WasmtimeBuildable + Send + Sync + 'static> http::Http for Http<T> {
         router: &Self::Router,
         route: &str,
         handler: &str,
-    ) -> Result<Self::Router, HttpError> {
+    ) -> Result<Self::Router, HttpRouterError> {
         // Router is a reference to the router proxy, so we need to clone it to get a
         // mutable reference to the router.
         let mut rclone = router.clone();
@@ -176,7 +176,7 @@ impl<T: WasmtimeBuildable + Send + Sync + 'static> http::Http for Http<T> {
         router: &Self::Router,
         route: &str,
         handler: &str,
-    ) -> Result<Self::Router, HttpError> {
+    ) -> Result<Self::Router, HttpRouterError> {
         // Router is a reference to the router proxy, so we need to clone it to get a
         // mutable reference to the router.
         let mut rclone = router.clone();
@@ -188,7 +188,7 @@ impl<T: WasmtimeBuildable + Send + Sync + 'static> http::Http for Http<T> {
         router: &Self::Router,
         route: &str,
         handler: &str,
-    ) -> Result<Self::Router, HttpError> {
+    ) -> Result<Self::Router, HttpRouterError> {
         // Router is a reference to the router proxy, so we need to clone it to get a
         // mutable reference to the router.
         let mut rclone = router.clone();
@@ -200,7 +200,7 @@ impl<T: WasmtimeBuildable + Send + Sync + 'static> http::Http for Http<T> {
         router: &Self::Router,
         route: &str,
         handler: &str,
-    ) -> Result<Self::Router, HttpError> {
+    ) -> Result<Self::Router, HttpRouterError> {
         // Router is a reference to the router proxy, so we need to clone it to get a
         // mutable reference to the router.
         let mut rclone = router.clone();
@@ -211,13 +211,13 @@ impl<T: WasmtimeBuildable + Send + Sync + 'static> http::Http for Http<T> {
         &mut self,
         address: &str,
         router: &Self::Router,
-    ) -> Result<Self::Server, HttpError> {
+    ) -> Result<Self::Server, HttpRouterError> {
         // Shared states for all routes
         let instance_builder = self.builder.as_ref().unwrap().clone();
 
         // The outer builder is used to define the route paths, while creating a scope
         // for the inner builder which passes states to the route handler.
-        let mut outer_builder: RouterBuilder<Body, http::HttpError> = Router::builder()
+        let mut outer_builder: RouterBuilder<Body, http::HttpRouterError> = Router::builder()
             .middleware(enable_cors_all())
             .data(instance_builder);
 
@@ -225,7 +225,7 @@ impl<T: WasmtimeBuildable + Send + Sync + 'static> http::Http for Http<T> {
         let mut inner_routes = vec![];
         for route in router.routes.iter() {
             // per route state
-            let mut inner_builder: RouterBuilder<Body, http::HttpError> = Router::builder();
+            let mut inner_builder: RouterBuilder<Body, http::HttpRouterError> = Router::builder();
             inner_builder = inner_builder.data(route.clone());
             match route.method {
                 Methods::GET => {
@@ -268,7 +268,7 @@ impl<T: WasmtimeBuildable + Send + Sync + 'static> http::Http for Http<T> {
         Ok(ServerInner { closer: arc_tx })
     }
 
-    fn server_stop(&mut self, server: &Self::Server) -> Result<(), HttpError> {
+    fn server_stop(&mut self, server: &Self::Server) -> Result<(), HttpRouterError> {
         // clone is needed here because we have a reference to `ServerInner`,
         // but we need ownership of `ServerInner` to stop it.
         let clone = server.clone();
@@ -278,14 +278,14 @@ impl<T: WasmtimeBuildable + Send + Sync + 'static> http::Http for Http<T> {
 
 async fn handler<T: WasmtimeBuildable + Send + Sync + 'static>(
     request: hyper::Request<Body>,
-) -> Result<hyper::Response<Body>, http::HttpError> {
+) -> Result<hyper::Response<Body>, http::HttpRouterError> {
     log::debug!("received request: {:?}", &request);
     let (parts, body) = request.into_parts();
 
     // Fetch states from the request, including the route name and builder.
     let route = parts
         .data::<Route>()
-        .ok_or_else(|| http::HttpError::InvalidUrl("missing route".to_owned()))?;
+        .ok_or_else(|| http::HttpRouterError::InvalidUrl("missing route".to_owned()))?;
 
     let instance_builder = parts
         .data::<Builder<T>>()

--- a/examples/http-demo/src/main.rs
+++ b/examples/http-demo/src/main.rs
@@ -6,7 +6,7 @@ use slight_http_handler_macro::register_handler;
 
 wit_bindgen_rust::import!("../../wit/http.wit");
 wit_bindgen_rust::import!("../../wit/keyvalue.wit");
-wit_error_rs::impl_error!(http::HttpError);
+wit_error_rs::impl_error!(http::HttpRouterError);
 wit_error_rs::impl_error!(keyvalue::KeyvalueError);
 
 fn main() -> Result<()> {
@@ -37,7 +37,7 @@ fn handle_hello(req: Request) -> Result<Response, HttpError> {
 
 #[register_handler]
 fn handle_foo(request: Request) -> Result<Response, HttpError> {
-    let keyvalue = crate::Keyvalue::open("my-container").unwrap();
+    let keyvalue = Keyvalue::open("my-container").unwrap();
     let value = keyvalue.get("key").unwrap();
     Ok(Response {
         headers: Some(request.headers),
@@ -51,7 +51,7 @@ fn handle_bar(request: Request) -> Result<Response, HttpError> {
     assert_eq!(request.method, Method::Put);
     println!("request body: {:?}", request.body);
     if let Some(body) = request.body {
-        let keyvalue = crate::Keyvalue::open("my-container").unwrap();
+        let keyvalue = Keyvalue::open("my-container").unwrap();
         println!("here1");
         keyvalue.set("key", &body).unwrap();
         println!("here2");

--- a/tests/http-test/src/main.rs
+++ b/tests/http-test/src/main.rs
@@ -4,7 +4,7 @@ use http::*;
 use slight_http_handler_macro::register_handler;
 
 wit_bindgen_rust::import!("../../wit/http.wit");
-wit_error_rs::impl_error!(http::HttpError);
+wit_error_rs::impl_error!(http::HttpRouterError);
 
 fn main() -> Result<()> {
     let router = Router::new()?;
@@ -81,14 +81,4 @@ fn upload(request: Request) -> Result<Response, HttpError> {
         body: request.body,
         status: 200,
     })
-}
-
-/// FIXME: We should come up with a solution that removes the need to register a 
-/// handle_http function. The reason this is needed because the host is 
-/// parsing the wit htto-handler file which has the handle_http function.        
-#[register_handler]
-fn handle_http(_req: Request) -> Result<Response, HttpError> {
-    Err(HttpError::UnexpectedError(
-        "this is a dummy handler".to_string(),
-    ))
 }

--- a/wit/http-handler.wit
+++ b/wit/http-handler.wit
@@ -1,3 +1,12 @@
-use { request, response, http-error } from http-types
+use { request, response } from http-types
+
+/// HTTP errors returned by the runtime.
+variant http-error {
+    invalid-url(string),
+    timeout-error(string),
+    protocol-error(string),
+    status-error(u16),
+    unexpected-error(string)
+}
 
 handle-http: func(req: request) -> expected<response, http-error>

--- a/wit/http-types.wit
+++ b/wit/http-types.wit
@@ -39,12 +39,3 @@ record response {
     headers: option<headers>,
     body: option<body>,
 }
-
-/// HTTP errors returned by the runtime.
-variant http-error {
-    invalid-url(string),
-    timeout-error(string),
-    protocol-error(string),
-    status-error(http-status),
-    unexpected-error(string)
-}

--- a/wit/http.wit
+++ b/wit/http.wit
@@ -1,29 +1,38 @@
-use { uri, http-error } from http-types
+use { uri, http-status } from http-types
+
+/// HTTP errors returned by the runtime.
+variant http-router-error {
+    invalid-url(string),
+    timeout-error(string),
+    protocol-error(string),
+    status-error(http-status),
+    unexpected-error(string)
+}
 
 resource router {
 	/// create a new HTTP router
-	static new: func() -> expected<router, http-error>
+	static new: func() -> expected<router, http-router-error>
 
     /// create a new HTTP router
-	static new-with-base: func(base: uri) -> expected<router, http-error>
+	static new-with-base: func(base: uri) -> expected<router, http-router-error>
 
 	/// register a HTTP GET route
-	get: func(route: string, handler: string) -> expected<router, http-error>
+	get: func(route: string, handler: string) -> expected<router, http-router-error>
 
 	/// register a HTTP PUT route
-	put: func(route: string, handler: string) -> expected<router, http-error>
+	put: func(route: string, handler: string) -> expected<router, http-router-error>
 
 	/// register a HTTP POST route
-	post: func(route: string, handler: string) -> expected<router, http-error>
+	post: func(route: string, handler: string) -> expected<router, http-router-error>
 
 	/// register a HTTP DELETE route
-	delete: func(route: string, handler: string) -> expected<router, http-error>
+	delete: func(route: string, handler: string) -> expected<router, http-router-error>
 }
 
 resource server {
 	/// create a new HTTP server and serve the given router
-    static serve: func(address: string, router: router) -> expected<server, http-error> // non-blocking
+    static serve: func(address: string, router: router) -> expected<server, http-router-error> // non-blocking
 
 	/// stop the server
-    stop: func() -> expected<unit, http-error>
+    stop: func() -> expected<unit, http-router-error>
 }


### PR DESCRIPTION
This PR adds a new error type to the http capability named `http-router-error`. Currently, the http capability and http handler are sharing the same error type. This makes it difficult to differentiate the `http-error` defined in the handler and  the one defined in the http capability. 

One of the benefits of splitting them out is that each HTTP handler function, now, can fully use the imports from its crate mod. For example, the http handler can now say
```rust
let keyvalue = Keyvalue::open("my-container").unwrap();
```

while previously a crate namespace is needed
```rust
let keyvalue = crate::Keyvalue::open("my-container").unwrap();
```

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>