### PR TITLE
tests: disabling the aws dynamodb integration test

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -99,15 +99,15 @@ mod integration_tests {
             Ok(())
         }
 
-        #[test]
-        fn aws_dynamodb_test() -> Result<()> {
-            let file_config = "./tests/keyvalue-test/keyvalue_awsdynamodb_slightfile.toml";
-            run(
-                SLIGHT,
-                vec!["-c", file_config, "run", "-m", KEYVALUE_TEST_MODULE],
-            );
-            Ok(())
-        }
+        // #[test]
+        // fn aws_dynamodb_test() -> Result<()> {
+        //     let file_config = "./tests/keyvalue-test/keyvalue_awsdynamodb_slightfile.toml";
+        //     run(
+        //         SLIGHT,
+        //         vec!["-c", file_config, "run", "-m", KEYVALUE_TEST_MODULE],
+        //     );
+        //     Ok(())
+        // }
 
         #[test]
         #[cfg(unix)] // TODO: Add Windows support


### PR DESCRIPTION
We are out of an AWS account to run integration tests on. Until we get a new account, we will disable AWS specific integration test. 

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>