### PR TITLE
tied slight version to interface version when using slight add or slight new

### DIFF
--- a/slight/src/commands/add.rs
+++ b/slight/src/commands/add.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::{create_dir_all, remove_dir_all, File},
-    io::{self, ErrorKind},
+    io::{self, ErrorKind}, process::Command,
 };
 
 use anyhow::Result;
@@ -15,7 +15,7 @@ const DISTRIBUTED_LOCKING_DOWNLOADS: [&str; 1] = ["distributed-locking"];
 const MESSAGING_DOWNLOADS: [&str; 1] = ["messaging"];
 
 pub async fn handle_add(what_to_add: &str, folder_prefix: Option<&str>) -> Result<()> {
-    let (interface, release, folder_name) = if !what_to_add.contains('@') {
+    let (interface, mut release, mut folder_name) = if !what_to_add.contains('@') {
         panic!("invalid usage: to add an interface to your project, say `slight add -i <interface-name>@<release-tag>`");
         // TODO: In the future, let's support omitting the release tag to download the latest release
     } else {
@@ -23,10 +23,30 @@ pub async fn handle_add(what_to_add: &str, folder_prefix: Option<&str>) -> Resul
         // ^^^ fine to unwrap, we are guaranteed to have a '@' at this point.
         (
             &what_to_add[..find_at],
-            &what_to_add[find_at + 1..],
+            what_to_add[find_at + 1..].to_string(),
             what_to_add.replace('@', "_"),
         )
     };
+
+    let output = Command::new("slight")
+        .arg("--version")
+        .output()
+        .expect("failed to execute process");
+
+    let version = String::from_utf8_lossy(&output.stdout);
+    let version = version.replace("slight", "").trim().to_string();
+
+    // if version is diff. from release, panic
+    release = if !version.eq(&release) {
+        // println that we are using release equal to version instead
+        println!("slight version {} is different from the release you are trying to add. slight will use version v{} instead.", release, version);
+        folder_name = folder_name.replace(&release, &format!("v{}", version));
+        format!("v{}", version)
+    } else {
+        release
+    };
+
+    // change folder name to have new release
 
     match what_to_add {
         _ if interface.eq("keyvalue")

--- a/slight/src/commands/add.rs
+++ b/slight/src/commands/add.rs
@@ -1,6 +1,7 @@
 use std::{
     fs::{create_dir_all, remove_dir_all, File},
-    io::{self, ErrorKind}, process::Command,
+    io::{self, ErrorKind},
+    process::Command,
 };
 
 use anyhow::Result;

--- a/slight/src/commands/new.rs
+++ b/slight/src/commands/new.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Context, Result};
 use flate2::bufread::GzDecoder;
 use std::io::Write;
+use std::process::Command;
 use std::{
     fs::{read_to_string, File},
     io::BufReader,
@@ -12,7 +13,7 @@ use crate::cli::Templates;
 use super::add::handle_add;
 
 pub async fn handle_new(name_at_release: &str, template: &Templates) -> Result<()> {
-    let (project_name, release) = if !name_at_release.contains('@') {
+    let (project_name, mut release) = if !name_at_release.contains('@') {
         panic!(
             "invalid usage: to start a new project, say `slight new -n <project-name>@<release-tag> <some-template>`"
         );
@@ -20,7 +21,27 @@ pub async fn handle_new(name_at_release: &str, template: &Templates) -> Result<(
     } else {
         let find_at = name_at_release.find('@').unwrap();
         // ^^^ fine to unwrap, we are guaranteed to have a '@' at this point.
-        (&name_at_release[..find_at], &name_at_release[find_at + 1..])
+        (
+            &name_at_release[..find_at],
+            name_at_release[find_at + 1..].to_string(),
+        )
+    };
+
+    let output = Command::new("slight")
+        .arg("--version")
+        .output()
+        .expect("failed to execute process");
+
+    let version = String::from_utf8_lossy(&output.stdout);
+    let version = version.replace("slight", "").trim().to_string();
+
+    // if version is diff. from release, panic
+    release = if !version.eq(&release) {
+        // println that we are using release equal to version instead
+        println!("slight version {} is different from the release you are trying to add. slight will use version v{} instead.", release, version);
+        format!("v{}", version)
+    } else {
+        release
     };
 
     // check project_name is not C or Rust
@@ -41,8 +62,8 @@ pub async fn handle_new(name_at_release: &str, template: &Templates) -> Result<(
     Archive::new(GzDecoder::new(BufReader::new(resp.as_ref()))).unpack("./")?;
 
     match template {
-        Templates::C => setup_c_template(project_name, release)?,
-        Templates::Rust => setup_rust_template(project_name, release)?,
+        Templates::C => setup_c_template(project_name, &release)?,
+        Templates::Rust => setup_rust_template(project_name, &release)?,
     };
 
     handle_add(


### PR DESCRIPTION
With this change, we are adding a check to see if the installed version of slight is the same version of the interface that the user is trying to utilize when running `slight new`, or `slight add`.

Signed-off-by: danbugs <danilochiarlone@gmail.com>