### PR TITLE
Chore: bump slight version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3725,7 +3725,7 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 
 [[package]]
 name = "slight"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "as-any",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "slight-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "slight-integration-tests"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercon
 `slight` relies on a WIT bindings generator [wit-bindgen v0.2.0](https://github.com/bytecodealliance/wit-bindgen), and currently only supports C and Rust applications. We are planning to add more language supports, such as Go and JavaScript/TypeScript.
 
 ```sh
-slight new -n spidey@v0.1.0 rust && cd spidey
-# ^^^ starts a new rust project under SpiderLightning's v0.1.0 spec
-# use: `slight new -n spidey@v0.1.0 c` to start a new c project
+slight new -n spidey@v0.4.0 rust && cd spidey
+# ^^^ starts a new rust project under SpiderLightning's v0.4.0 spec
+# use: `slight new -n spidey@v0.4.0 c` to start a new c project
 
 cargo build --target wasm32-wasi
 # ^^^ for c...

--- a/templates/rust/Cargo.toml
+++ b/templates/rust/Cargo.toml
@@ -12,7 +12,7 @@ wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", ta
 # ^^^ A language binding generator for WebAssembly interface types
 wit-error-rs = { git = "https://github.com/danbugs/wit-error-rs", rev = "05362f1a4a3a9dc6a1de39195e06d2d5d6491a5e" }
 # ^^^ Convenience error-related trait implementations for types generated from a wit-bindgen import
-slight-http-handler-macro = { git = "https://github.com/deislabs/spiderlightning", rev = "efbae2d696713cd6bc559155db9ab4b4277bab08" }
+slight-http-handler-macro = { git = "https://github.com/deislabs/spiderlightning", tag = "0.4.0" }
 # ^^^ Macro for creating http request handlers when using SpiderLightning's http interface
 
 [workspace]


### PR DESCRIPTION
This PR bumps the slight CLI to version 0.4.0. 

Do we have a story of when to bump SpiderLightning capability versions, like wasi-keyvalue? They are still at `v0.1.0` now. 