### PR TITLE
Bug: Fixed typos in `add` command and added integration tests

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -3,7 +3,7 @@ use std::{
     io::{self, ErrorKind},
 };
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use slight_core::interface_parser::InterfaceAtRelease;
 
 const GITHUB_URL: &str = "https://github.com/deislabs/spiderlightning/releases/download";
@@ -24,33 +24,37 @@ pub async fn handle_add(
 ) -> Result<()> {
     let (interface, release) = (what_to_add.name, what_to_add.version.to_string());
     let folder_name = format!("{interface}_{release}");
-
-    match interface.as_str() {
-        "keyvalue"
-        | "configs"
-        | "http-server"
-        | "http-client"
-        | "distributed_locking"
-        | "messaging"
-        | "sql" => {
-            maybe_recreate_dir(&format!("{}{}", folder_prefix.unwrap_or("./"), folder_name))?;
-            for i in get_interface_downloads_by_name(&interface) {
-                let resp = reqwest::get(format!("{GITHUB_URL}/v{release}/{i}.wit"))
-                    .await?
-                    .text()
-                    .await?;
-                let mut out = File::create(format!(
-                    "{}{}/{}.wit",
-                    folder_prefix.unwrap_or("./"),
-                    folder_name,
-                    i
-                ))?;
-                io::copy(&mut resp.as_bytes(), &mut out)?;
+    let interfaces = get_interface_downloads_by_name(&interface);
+    tracing::info!(
+        "Downloading interface {} for release v{} to {}",
+        interface,
+        release,
+        folder_name
+    );
+    if !interfaces.is_empty() {
+        maybe_recreate_dir(&format!("{}{}", folder_prefix.unwrap_or("./"), folder_name))?;
+        for i in interfaces.iter() {
+            let resp = reqwest::get(format!("{GITHUB_URL}/v{release}/{i}.wit")).await?;
+            if !resp.status().is_success() {
+                bail!(
+                    "could not find interface {} for release v{}, pleases see all releases in {}",
+                    interface,
+                    release,
+                    GITHUB_URL
+                );
             }
+            let resp = resp.text().await?;
+            tracing::info!("writing {} to {}/{}.wit", i, folder_name, i);
+            let mut out = File::create(format!(
+                "{}{}/{}.wit",
+                folder_prefix.unwrap_or("./"),
+                folder_name,
+                i
+            ))?;
+            io::copy(&mut resp.as_bytes(), &mut out)?;
         }
-        _ => {
-            panic!("{}", ERROR_MSG)
-        }
+    } else {
+        bail!("{}", ERROR_MSG);
     }
     Ok(())
 }
@@ -58,7 +62,7 @@ pub async fn handle_add(
 fn maybe_recreate_dir(dir_name: &str) -> Result<()> {
     match remove_dir_all(dir_name) {
         Err(e) if e.kind() != ErrorKind::NotFound => {
-            panic!("{}", e);
+            bail!("{}", e);
         }
         _ => {
             create_dir_all(dir_name)?;
@@ -72,13 +76,13 @@ pub fn get_interface_downloads_by_name(name: &str) -> Vec<&str> {
     match name {
         _ if name.eq("keyvalue") => KEYVALUE_DOWNLOADS.to_vec(),
         _ if name.eq("configs") => CONFIGS_DOWNLOADS.to_vec(),
-        _ if name.eq("http_server") => HTTP_DOWNLOADS.to_vec(),
-        _ if name.eq("http_client") => HTTP_CLIENT_DOWNLOADS.to_vec(),
-        _ if name.eq("distributed_locking") => DISTRIBUTED_LOCKING_DOWNLOADS.to_vec(),
+        _ if name.eq("http-server") => HTTP_DOWNLOADS.to_vec(),
+        _ if name.eq("http-client") => HTTP_CLIENT_DOWNLOADS.to_vec(),
+        _ if name.eq("distributed-locking") => DISTRIBUTED_LOCKING_DOWNLOADS.to_vec(),
         _ if name.eq("messaging") => MESSAGING_DOWNLOADS.to_vec(),
         _ if name.eq("sql") => SQL_DOWNLOADS.to_vec(),
         _ => {
-            panic!("{}", ERROR_MSG)
+            vec![]
         }
     }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -383,5 +383,36 @@ mod integration_tests {
             assert!(String::from_utf8(output.stdout)?.contains("Hello, SpiderLightning!"));
             Ok(())
         }
+
+        #[test]
+        fn slight_add_tests() -> anyhow::Result<()> {
+            let capabilities = vec![
+                "keyvalue",
+                "configs",
+                "http-server",
+                "http-client",
+                "distributed-locking",
+                "messaging",
+                "sql",
+            ];
+            let version = "v0.3.1";
+
+            let tmpdir = tempdir::TempDir::new("tests")?;
+            for cap in capabilities {
+                let output = Command::new(slight_path())
+                    .args(["add", &format!("{cap}@{version}")])
+                    .current_dir(&tmpdir)
+                    .output()?;
+                assert!(output.status.success());
+            }
+
+            let ill_version = "v0.5763.2355";
+            let output = Command::new(slight_path())
+                .args(["add", &format!("keyvalue@{ill_version}")])
+                .current_dir(&tmpdir)
+                .output()?;
+            assert!(!output.status.success());
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
This PR fixed a few typos in the `Add` command which causes failures to download `http-server` and `http-client` WIT interfaces. 

The issue was that the handle_add function uses kebab name for `http-server` and `http-client` but the `get_interface_downloads_by_name` uses snake name for them. This mismatch causes the function to be unsuable for downloading these two interfaces. 

This PR also adds some tracing statements into the Add command and it looks like this:
![image](https://user-images.githubusercontent.com/5447827/221378106-0bd0b9dd-e51f-488b-bc44-3b62e2cc00b2.png)

In addition, it adds an extra check statement `!resp.status().is_success()` to check whether the request interface returns a status code of success, which prevents users to download non-existing interfaces. Previously they will silently succeed and download interfaces which container "not found" as the only content. Now these requests will be rejected with an error saying the the requests interfaces could not be found.

Lastly, it adds one integration tests on `slight add` command to do sanity checks. 
