### PR TITLE
Fix team name typo

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,5 @@
 $INSTALL_DIR="C:\slight"
-$OWNER_AND_REPO="deislabds/spiderlightning"
+$OWNER_AND_REPO="deislabs/spiderlightning"
 $TAR="slight-windows-x86_64.tar.gz"
 $BINARY_NAME="slight.exe"
 


### PR DESCRIPTION
The team name is incorrect, so the GitHub API request will fail to get the latest release tag, and installation will fail. Changing to correct team name and verified installation using Win10/11