### PR TITLE
Chore: Bump to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3639,7 +3639,7 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 
 [[package]]
 name = "slight"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "as-any",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "slight-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "slight-integration-tests"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ http-server = ["dep:slight-http-server"]
 http-client = ["dep:slight-http-client"]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercon
 `slight` relies on a WIT bindings generator [wit-bindgen v0.2.0](https://github.com/bytecodealliance/wit-bindgen), and currently only supports C and Rust applications. We are planning to add more language supports, such as Go and JavaScript/TypeScript.
 
 ```sh
-slight new -n spidey@v0.3.2 rust && cd spidey
+slight new -n spidey@v0.3.3 rust && cd spidey
 # ^^^ starts a new rust project under SpiderLightning's v0.1.0 spec
-# use: `slight new -n spidey@v0.3.2 c` to start a new c project
+# use: `slight new -n spidey@v0.3.3 c` to start a new c project
 
 cargo build --target wasm32-wasi
 # ^^^ for c...

--- a/templates/rust/Cargo.toml
+++ b/templates/rust/Cargo.toml
@@ -12,7 +12,7 @@ wit-bindgen-rust = { git = "https://github.com/fermyon/wit-bindgen-backport" }
 # ^^^ A language binding generator for WebAssembly interface types
 wit-error-rs = { git = "https://github.com/danbugs/wit-error-rs", rev = "05362f1a4a3a9dc6a1de39195e06d2d5d6491a5e" }
 # ^^^ Convenience error-related trait implementations for types generated from a wit-bindgen import
-slight-http-handler-macro = { git = "https://github.com/deislabs/spiderlightning", tag = "v0.3.2" }
+slight-http-handler-macro = { git = "https://github.com/deislabs/spiderlightning", tag = "v0.3.3" }
 # ^^^ Macro for creating http request handlers when using SpiderLightning's http interface
 
 [workspace]


### PR DESCRIPTION
Prepare for a new release of v0.3.3 to include an update to wasmtime `v5.0.0` using wit-bindgen-backport 