### PR TITLE
CI: Update Windows CI to the correct openssl path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,7 @@ jobs:
         run: make build
         if: ${{ fromJSON(matrix.config.os == 'windows-latest') }}
         env:
-          OPENSSL_DIR: C:\Program Files\OpenSSL-Win64\
+          OPENSSL_DIR: C:\Program Files\OpenSSL\
           OPENSSL_NO_VENDOR: true
 
       #
@@ -144,7 +144,7 @@ jobs:
         run: make test
         if: ${{ fromJSON(matrix.config.os == 'windows-latest') }}
         env:
-          OPENSSL_DIR: C:\Program Files\OpenSSL-Win64\
+          OPENSSL_DIR: C:\Program Files\OpenSSL\
           OPENSSL_NO_VENDOR: true
 
       #

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -95,7 +95,7 @@ stages:
           #
           # Update build environment
           #
-          - bash: |
+          - script: |
               rustup default stable
               rustup update stable
               rustup target add wasm32-wasi

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -97,9 +97,9 @@ stages:
           #
           - script: |
               rustup default stable
-              rustup update stable
               rustup target add wasm32-wasi
               rustup target add wasm32-unknown-unknown
+              rustup update stable
             displayName: rustup update default toolchain
 
           #

--- a/build/azure-pipeline/workflow-pr.yml
+++ b/build/azure-pipeline/workflow-pr.yml
@@ -139,7 +139,7 @@ stages:
             displayName: Build Windows   
             condition: and(succeeded(), eq(variables['target_os'], 'windows'))
             env:
-              OPENSSL_DIR: C:\Program Files\OpenSSL-Win64\
+              OPENSSL_DIR: C:\Program Files\OpenSSL\
               OPENSSL_NO_VENDOR: true
 
           #


### PR DESCRIPTION
The current path to openssl.exe on Win agents is `C:\Program Files\OpenSSL`