### PR TITLE
fix: remove tempdir crate and replace it with tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,12 +2006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3475,19 +3469,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -3529,21 +3510,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3628,15 +3594,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "redis"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3716,15 +3673,6 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -4269,7 +4217,11 @@ dependencies = [
  "clap",
  "flate2",
  "log",
+<<<<<<< Updated upstream
  "rand 0.8.5",
+=======
+ "rand 0.7.3",
+>>>>>>> Stashed changes
  "reqwest",
  "slight-blob-store",
  "slight-common",
@@ -4284,7 +4236,6 @@ dependencies = [
  "slight-runtime-configs",
  "slight-sql",
  "tar",
- "tempdir",
  "tempfile",
  "tokio",
  "toml 0.7.3",
@@ -4336,7 +4287,7 @@ dependencies = [
  "semver 1.0.14",
  "short-crypt",
  "slight-file",
- "tempdir",
+ "tempfile",
  "toml 0.7.3",
 ]
 
@@ -4445,7 +4396,7 @@ dependencies = [
  "mosquitto-rs",
  "rand 0.8.5",
  "signal-child",
- "tempdir",
+ "tempfile",
  "tokio",
 ]
 
@@ -4532,7 +4483,7 @@ dependencies = [
  "slight-common",
  "slight-core",
  "slight-file",
- "tempdir",
+ "tempfile",
  "toml 0.7.3",
  "tracing",
  "wit-bindgen-wasmtime 0.2.0 (git+https://github.com/fermyon/wit-bindgen-backport)",
@@ -4776,16 +4727,6 @@ name = "target-lexicon"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4217,11 +4217,7 @@ dependencies = [
  "clap",
  "flate2",
  "log",
-<<<<<<< Updated upstream
  "rand 0.8.5",
-=======
- "rand 0.7.3",
->>>>>>> Stashed changes
  "reqwest",
  "slight-blob-store",
  "slight-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ flate2 = "1"
 tar = "0.4"
 
 [dev-dependencies]
-tempdir = { workspace = true }
 tempfile = { workspace = true }
 rand = { worspace = true }
 
@@ -87,8 +86,7 @@ async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1", features = ["log"] }
 toml = "0.7"
-tempdir = "0.3"
-tempfile = "3.4"
+tempfile = "3.5"
 log = { version = "0.4", default-features = false }
 env_logger = "0.10"
 as-any = "0.3"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,4 +19,4 @@ semver = { workspace = true }
 slight-file = { workspace = true }
 
 [dev-dependencies]
-tempdir = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/core/src/secret.rs
+++ b/crates/core/src/secret.rs
@@ -98,14 +98,14 @@ mod unittests {
     use std::{fs::OpenOptions, io::Write};
 
     use anyhow::Result;
-    use tempdir::TempDir;
+    use tempfile::tempdir;
 
     use super::create_secret;
     use slight_file::SlightFile;
 
     #[test]
     fn create_secret_test() -> Result<()> {
-        let dir = TempDir::new("tmp")?;
+        let dir = tempdir()?;
         let toml_file_pathpuf = dir.path().join("slightfile.toml");
         let toml_file_pathstr = toml_file_pathpuf.to_str().unwrap();
 
@@ -123,7 +123,7 @@ mod unittests {
 
     #[test]
     fn add_new_secret() -> Result<()> {
-        let dir = TempDir::new("tmp")?;
+        let dir = tempdir()?;
         let toml_file_pathpuf = dir.path().join("slightfile.toml");
         let toml_file_pathstr = toml_file_pathpuf.to_str().unwrap();
 
@@ -174,7 +174,7 @@ mod unittests {
 
     #[test]
     fn change_existing_secret() -> Result<()> {
-        let dir = TempDir::new("tmp")?;
+        let dir = tempdir()?;
         let toml_file_pathpuf = dir.path().join("slightfile.toml");
         let toml_file_pathstr = toml_file_pathpuf.to_str().unwrap();
 
@@ -211,7 +211,7 @@ mod unittests {
 
     #[test]
     fn change_duplicate_secret() -> Result<()> {
-        let dir = TempDir::new("tmp")?;
+        let dir = tempdir()?;
         let toml_file_pathpuf = dir.path().join("slightfile.toml");
         let toml_file_pathstr = toml_file_pathpuf.to_str().unwrap();
 

--- a/crates/runtime-configs/Cargo.toml
+++ b/crates/runtime-configs/Cargo.toml
@@ -25,4 +25,4 @@ async-trait = { workspace = true }
 regex = "1.6"
 
 [dev-dependencies]
-tempdir = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/runtime-configs/src/implementors/usersecrets.rs
+++ b/crates/runtime-configs/src/implementors/usersecrets.rs
@@ -70,13 +70,13 @@ mod unittests {
 
     use anyhow::Result;
     use slight_file::SlightFile;
-    use tempdir::TempDir;
+    use tempfile::tempdir;
 
     use super::UserSecrets;
 
     #[test]
     fn set_then_get_test() -> Result<()> {
-        let dir = TempDir::new("tmp")?;
+        let dir = tempdir()?;
         let toml_file_pathpuf = dir.path().join("slightfile.toml");
         let toml_file_pathstr = toml_file_pathpuf.to_str().unwrap();
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -17,7 +17,7 @@ hyper = { workspace = true, features = ["full"] }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 mosquitto-rs = { version = "0.4.0", features = ["vendored-openssl", "vendored-mosquitto"] }
-tempdir = { workspace = true }
+tempfile = { workspace = true }
 rand = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -500,7 +500,7 @@ mod integration_tests {
 
         #[test]
         fn slight_new_rust() -> anyhow::Result<()> {
-            let tmpdir = tempdir::TempDir::new("tests")?;
+            let tmpdir = tempfile::tempdir()?;
             let mut child = Command::new(slight_path())
                 .args(["new", "--name-at-release", "my-demo@v0.4.0", "rust"])
                 .current_dir(&tmpdir)
@@ -545,7 +545,7 @@ mod integration_tests {
             ];
             let version = "v0.4.0";
 
-            let tmpdir = tempdir::TempDir::new("tests")?;
+            let tmpdir = tempfile::tempdir()?;
             for cap in capabilities {
                 let output = Command::new(slight_path())
                     .args(["add", &format!("{cap}@{version}")])
@@ -574,7 +574,7 @@ mod integration_tests {
             wits.sort();
             let version = "v0.4.0";
 
-            let tmpdir = tempdir::TempDir::new("tests")?;
+            let tmpdir = tempfile::tempdir()?;
 
             let output = Command::new(slight_path())
                 .args(["add", &format!("{cap}@{version}", cap = "http-server")])


### PR DESCRIPTION
The tempdir crate was an out-of-date crate that depends on a older version of `rand`, which causes some issues on our tests when we import `Alphanumeric` from `rand`. 

Since `tempfile` is a crate meant to replace `tempdir`, this PR replaces it to `tempfile`. 

This should make #384 pass the CI