### PR TITLE
Fix typo in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ wizer = { git = "https://github.com/bytecodealliance/wizer", rev = "c7e07054d04c
 
 [dev-dependencies]
 tempfile = { workspace = true }
-rand = { worspace = true }
+rand = { workspace = true }
 
 [features]
 default = ["blob-store", "keyvalue", "distributed-locking", "messaging", "runtime-configs", "sql", "http-server", "http-client"]


### PR DESCRIPTION
A typo in `Cargo.toml` was causing unnecessary warnings in dev builds:

```shell
% cargo build
warning: /Users/matt/projects/spiderlightning/Cargo.toml:
  dependency (rand) specified without providing a local path, Git repository, version, or workspace dependency to use. This will be considered an error in future versions
warning: /Users/matt/projects/spiderlightning/Cargo.toml:
  unused manifest key: dev-dependencies.rand.worspace
...
```

It builds silently after this change.