### PR TITLE
Windows installer - Remove Update-SessionEnvironment dependency

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -18,14 +18,13 @@ tar -xf "$INSTALL_DIR\$TAR" -C $INSTALL_DIR
 mv -Force "$INSTALL_DIR\release\$BINARY_NAME" $INSTALL_DIR
 ">>> EXTRACTED BINARY TAR."
 
-Update-SessionEnvironment
 $PATH_CONTENT = [Environment]::GetEnvironmentVariable('path', 'User')
 if ($PATH_CONTENT -ne $null)
 {
   if ($PATH_CONTENT -split ';'  -NotContains  $INSTALL_DIR)
   {
     [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'User') + ";$INSTALL_DIR" , [System.EnvironmentVariableTarget]::User)
-    Update-SessionEnvironment
+    $env:Path += ";$INSTALL_DIR"
   }
 }
 ">>> INSTALLED BINARY."


### PR DESCRIPTION
The [Update-SessionEnvironment](https://docs.chocolatey.org/en-us/create/functions/update-sessionenvironment) is an implementation of Chocolatey to refresh all the session environment variables. If Chocolatey is not installed, this will fail.  Given that the only variable that is updated is $Path, we only need to refresh that one for the current session, and we can do that manually. 